### PR TITLE
siac: Add --insecure-input flag for wallet unlock

### DIFF
--- a/cmd/siac/main.go
+++ b/cmd/siac/main.go
@@ -84,6 +84,7 @@ var (
 	walletStartHeight    uint64 // Start height for transaction search.
 	walletEndHeight      uint64 // End height for transaction search.
 	walletTxnFeeIncluded bool   // include the fee in the balance being sent
+	insecureInput        bool   // Insecure password/seed input. Disables the shoulder-surfing and Mac secure input feature.
 )
 
 var (
@@ -382,6 +383,7 @@ func initCmds() *cobra.Command {
 	walletLoadCmd.AddCommand(walletLoad033xCmd, walletLoadSeedCmd, walletLoadSiagCmd)
 	walletSendCmd.AddCommand(walletSendSiacoinsCmd, walletSendSiafundsCmd)
 	walletSendSiacoinsCmd.Flags().BoolVarP(&walletTxnFeeIncluded, "fee-included", "", false, "Take the transaction fee out of the balance being submitted instead of the fee being additional")
+	walletUnlockCmd.Flags().BoolVarP(&insecureInput, "insecure-input", "", false, "Disable shoulder-surf protection (echoing passwords and seeds)")
 	walletUnlockCmd.Flags().BoolVarP(&initPassword, "password", "p", false, "Display interactive password prompt even if SIA_WALLET_PASSWORD is set")
 	walletBroadcastCmd.Flags().BoolVarP(&walletRawTxn, "raw", "", false, "Decode transaction as base64 instead of JSON")
 	walletSignCmd.Flags().BoolVarP(&walletRawTxn, "raw", "", false, "Encode signed transaction as base64 instead of JSON")

--- a/cmd/siad/daemon.go
+++ b/cmd/siad/daemon.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"gitlab.com/NebulousLabs/errors"
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 
 	"go.sia.tech/siad/build"
 	"go.sia.tech/siad/modules"
@@ -23,7 +23,7 @@ import (
 // passwordPrompt securely reads a password from stdin.
 func passwordPrompt(prompt string) (string, error) {
 	fmt.Print(prompt)
-	pw, err := terminal.ReadPassword(int(syscall.Stdin))
+	pw, err := term.ReadPassword(int(syscall.Stdin))
 	fmt.Println()
 	return string(pw), err
 }

--- a/go.mod
+++ b/go.mod
@@ -30,4 +30,5 @@ require (
 	gitlab.com/NebulousLabs/writeaheadlog v0.0.0-20200618142844-c59a90f49130
 	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2
 	golang.org/x/net v0.0.0-20210410081132-afb366fc7cd1
+	golang.org/x/term v0.0.0-20210421210424-b80969c67360
 )

--- a/go.sum
+++ b/go.sum
@@ -202,8 +202,9 @@ golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44 h1:Bli41pIlzTzf3KEY06n+xnzK/BESIg2ze4Pgfh/aI8c=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/term v0.0.0-20210421210424-b80969c67360 h1:3xb4xj+MkwmausKqTNIEMLZsruJPu6p3jrlW8p3eecY=
+golang.org/x/term v0.0.0-20210421210424-b80969c67360/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.6 h1:aRYxNxv6iGQlyVaZmk6ZgYEDa+Jg18DxebPSrd6bg1M=


### PR DESCRIPTION
Sometimes you're alone and not worried about anyone peeking over your
shoulder. In such cases, masking and hiding the user input is of little
value. The only non-shoulder-surf security mechanism this would disable
is the Apple Secure Keyboard Entry. This commit does not change the
default behavior.

Other notes, I replaced the "golang.org/x/crypto/ssh/terminal"
dependency with its indirect import, "golang.org/x/term", as the
former is deprecated in favor of the latter.

This feature was requested on Reddit and seemed rather sane: https://www.reddit.com/r/siacoin/comments/mvmq93/feature_request_display_user_input_at_the_wallet/

There may also be a better name than "insecure-input". "no-shoulder-surf" didn't sound as descriptive...