### PR TITLE
Add dockerfile

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,0 +1,35 @@
+name: Docker Publish
+
+# Controls when the action will run. 
+on:
+  # Triggers the workflow on new SemVer tags
+  push:
+    tags: 
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: docker/setup-qemu-action@v1
+      - uses: docker/setup-buildx-action@v1
+      - uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: crazy-max/ghaction-docker-meta@ae431178c17085afd420fdf7ca88b37bd32e3d7d
+        name: generate tags
+        id: meta
+        with:
+          images: ghcr.io/siafoundation/siad
+          tags: |
+            type=semver,pattern={{version}}
+      - uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+# build sia
+FROM golang:1.16-alpine AS build
+
+WORKDIR /app
+
+COPY . .
+
+# need to run git status first to fix GIT_DIRTY detection in makefile
+RUN apk update \
+	&& apk add --no-cache git make ca-certificates \
+	&& update-ca-certificates \
+	&& git status > /dev/null \
+	&& make static
+
+FROM alpine:latest
+
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=build /app/release /
+
+# gateway port
+EXPOSE 9981/tcp
+# host RHP2 port
+EXPOSE 9982/tcp
+# host RHP3 port
+EXPOSE 9983/tcp
+
+# SIA_WALLET_PASSWORD is used to automatically unlock the wallet
+ENV SIA_WALLET_PASSWORD=
+# SIA_API_PASSWORD sets the password used for API authentication
+ENV SIA_API_PASSWORD=
+
+VOLUME [ "/sia-data" ]
+
+ENTRYPOINT [ "/siad", "--disable-api-security", "-d", "/sia-data", "--api-addr", ":9980" ]

--- a/Makefile
+++ b/Makefile
@@ -144,6 +144,9 @@ dev:
 dev-race:
 	GORACE='$(racevars)' go install -race -tags='dev debug profile netgo' -ldflags='$(ldflags)' $(pkgs)
 
+static:
+	go build -o release/ -tags='netgo' -ldflags='-s -w $(ldflags)' $(release-pkgs)
+
 # release builds and installs release binaries.
 release:
 	go install -tags='netgo' -ldflags='-s -w $(ldflags)' $(release-pkgs)


### PR DESCRIPTION
I figured we could get the ball rolling. Automated builds could either use GitHub's repo or DockerHub. I'm personally more in favor of DockerHub because of its first party nature and additional exposure, but it would require setting up an additional Sia Foundation org there and using GitHub secrets. 

To do:
- [x] Create Dockerfile
- [x] Automated build + push using buildx