### PR TITLE
host: update sync check for testing for EAs

### DIFF
--- a/modules/host/accountmanager.go
+++ b/modules/host/accountmanager.go
@@ -416,7 +416,8 @@ func (am *accountManager) callConsensusChanged(cc modules.ConsensusChange, oldHe
 
 	// If the host is not synced, withdrawals are disabled. In this case we
 	// also do not want to rotate the fingerprints.
-	if !cc.Synced && build.Release != "testing" {
+	allowForTest := build.Release != "testing" || am.h.dependencies.Disrupt("OutOfSyncInTest")
+	if !cc.Synced && allowForTest {
 		am.withdrawalsInactive = true
 		return
 	}

--- a/modules/host/accountmanager.go
+++ b/modules/host/accountmanager.go
@@ -416,7 +416,7 @@ func (am *accountManager) callConsensusChanged(cc modules.ConsensusChange, oldHe
 
 	// If the host is not synced, withdrawals are disabled. In this case we
 	// also do not want to rotate the fingerprints.
-	if !cc.Synced {
+	if !cc.Synced && build.Release != "testing" {
 		am.withdrawalsInactive = true
 		return
 	}

--- a/modules/host/accountmanager_test.go
+++ b/modules/host/accountmanager_test.go
@@ -1122,7 +1122,7 @@ func TestAccountWithdrawalsInactive(t *testing.T) {
 	t.Parallel()
 
 	// Prepare a host
-	ht, err := blankHostTester(t.Name())
+	ht, err := blankMockHostTester(&dependencies.HostOutOfSyncInTest{}, t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/siatest/dependencies/host.go
+++ b/siatest/dependencies/host.go
@@ -93,3 +93,14 @@ func NewHostMaxEphemeralAccountRiskReached(duration time.Duration) modules.Depen
 func (d *HostMDMProgramDelayedWrite) Disrupt(s string) bool {
 	return s == "MDMProgramOutputDelayWrite"
 }
+
+// HostOutOfSyncInTest is a dependency that allows for the host to be seen as
+// out of sync in testing.
+type HostOutOfSyncInTest struct {
+	modules.ProductionDependencies
+}
+
+// Disrupt returns true if the correct string is provided.
+func (d *HostOutOfSyncInTest) Disrupt(s string) bool {
+	return s == "OutOfSyncInTest"
+}


### PR DESCRIPTION
In testing we often see downloads failing for `not enough workers`. One of the main contributing cases for this is when a host is viewed as not being synced and therefore put into maintenance cooldown. This case of the host being out of sync can be easily triggered in testing due to being able to rapidly mine blocks.  

This MR allows for ignoring out-of-sync hosts in testing. For testing the condition of handling out-of-sync hosts we can use a dependency to specifically handle that case. 
