### PR TITLE
Add lint & test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,51 @@
+name: Test
+
+on:
+  pull_request:
+    branches: [ master ]
+  push:
+    branches: [ master ]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: lint
+        uses: golangci/golangci-lint-action@5c56cd6c9dc07901af25baab6f2b0d9f3b7c3018
+        with:
+          version: v1.37.1
+      - name: analyze
+        run: |
+          go get gitlab.com/NebulousLabs/analyze
+          make analyze
+      - name: gofmt 
+        run: make fmt
+      - name: go vet
+        run: make vet
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ darwin, linux, windows ]
+        arch: [ arm64, amd64 ]
+        exclude:
+          - os: windows
+            arch: arm64
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ^v1.16
+      - name: build ${{ matrix.os }}/${{ matrix.arch }}
+        run: GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} make static
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    needs: [ lint, build ]
+    steps:
+      - uses: actions/checkout@v2
+      - name: test
+        uses: n8maninger/action-golang-test@503bdd1b410aa26740cad03f1214abc8beef5496
+        with:
+          args: "-race;-failfast;-tags=testing debug netgo"

--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,10 @@ fmt:
 vet:
 	go vet $(pkgs)
 
+analyze:
+	analyze -lockcheck=false -- $(pkgs)
+	analyze -lockcheck -- $(lockcheckpkgs)
+
 # lint runs golangci-lint.
 lint:
 	golangci-lint run -c .golangci.yml ./...

--- a/cmd/siac/maincmd_test.go
+++ b/cmd/siac/maincmd_test.go
@@ -78,7 +78,7 @@ Renter Rate limits:
   Upload Speed:   (no limit|\d+(\.\d+)? (B/s|KB/s|MB/s|GB/s|TB/s))`
 
 	connectionRefusedPattern := `Could not get consensus status: \[failed to get reader response; GET request failed; Get "?http://localhost:5555/consensus"?: dial tcp \[::1\]:5555: connect: connection refused\]`
-	siaClientVersionPattern := "siac v" + strings.ReplaceAll(build.NodeVersion, ".", `\.`)
+	siaClientVersionPattern := "siac v" + escapeRegexChars(build.NodeVersion)
 
 	// Define subtests
 	// We can't test siad on default address (port) when test node has


### PR DESCRIPTION
Adds linting and testing to Sia's workflows. Will lint, build and test on PR's and pushes to master.

These two tests are failing in the runner and on my local machine:
```
go.sia.tech/siad/modules/consensus/TestSendBlocksBroadcastsOnce
go.sia.tech/siad/siatest/renter/TestRenterBubble
```

These tests commonly fail, but have passed in the runner:
```
go.sia.tech/siad/modules/host/contractmanager/TestAddVirtualSectorOverflow
go.sia.tech/siad/modules/host/TestRPCSubscribe/SubscribeBeforeAvailable
go.sia.tech/siad/modules/host/TestRPCSubscribe
go.sia.tech/siad/modules/renter/TestRenterCanAccessEphemeralAccountHostSettings
go.sia.tech/siad/modules/renter/TestRenterListDirectory
go.sia.tech/siad/modules/renter/TestAccount
go.sia.tech/siad/siatest/host/TestHostBandwidth
go.sia.tech/siad/siatest/renter/contractor/TestFreshSettingsForRenew
go.sia.tech/siad/siatest/renter/TestLocalRepairCorrupted
```