### PR TITLE
Fix build.Critical triggering in uploadchunkdistributionqueue.go

### DIFF
--- a/modules/renter/uploadchunkdistributionqueue.go
+++ b/modules/renter/uploadchunkdistributionqueue.go
@@ -138,11 +138,6 @@ func (ucdq *uploadChunkDistributionQueue) callAddUploadChunk(uc *unfinishedUploa
 	// bumped.
 	ucdq.priorityLane.PushBack(uc)
 	if ucdq.lowPriorityLane.Len() == 0 {
-		// Consistency check
-		if ucdq.priorityBuildup != 0 {
-			ucdq.staticRenter.log.Critical("there should be no buildup if there is nothing in the low priority lane")
-		}
-
 		// No need to worry about priority buildup if there is nothing waiting
 		// in the low priority lane.
 		return

--- a/modules/renter/uploadchunkdistributionqueue.go
+++ b/modules/renter/uploadchunkdistributionqueue.go
@@ -155,7 +155,7 @@ func (ucdq *uploadChunkDistributionQueue) callAddUploadChunk(uc *unfinishedUploa
 	for x := ucdq.lowPriorityLane.Pop(); x != nil; x = ucdq.lowPriorityLane.Pop() {
 		// If there is buildup, add the item.
 		needed := x.staticMemoryNeeded * lowPriorityMinThroughputMultiplier
-		if ucdq.priorityBuildup > needed {
+		if ucdq.priorityBuildup >= needed {
 			ucdq.priorityBuildup -= needed
 			ucdq.priorityLane.PushBack(x)
 			continue
@@ -218,11 +218,19 @@ func (ucdq *uploadChunkDistributionQueue) threadedProcessQueue() {
 		}
 		ucdq.mu.Unlock()
 
-		// While not holding the lock but still blocking, pass the chunk off to
-		// the thread that will distribute the chunk to workers. This call can
-		// fail. If the call failed, the chunk should be re-inserted into the
-		// front of the low prior heap IFF the chunk was a low prio chunk.
-		distributed := ucdq.staticRenter.managedDistributeChunkToWorkers(nextUC)
+		var distributed bool
+		if ucdq.staticRenter.deps.Disrupt("DelayChunkDistribution") {
+			// Simulate chunk distribution but don't actually distribute it.
+			time.Sleep(time.Second)
+			distributed = true
+		} else {
+			// While not holding the lock but still blocking, pass the chunk off to
+			// the thread that will distribute the chunk to workers. This call can
+			// fail. If the call failed, the chunk should be re-inserted into the
+			// front of the low prior heap IFF the chunk was a low prio chunk.
+			distributed = ucdq.staticRenter.managedDistributeChunkToWorkers(nextUC)
+		}
+
 		// If the chunk was not distributed, we want to block briefly to give
 		// the workers time to process the items in their queue. The only reason
 		// that a chunk will not be distributed is because workers have too much

--- a/modules/renter/uploadchunkdistributionqueue_test.go
+++ b/modules/renter/uploadchunkdistributionqueue_test.go
@@ -1,9 +1,7 @@
 package renter
 
 import (
-	"fmt"
 	"io/ioutil"
-	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -191,30 +189,7 @@ func TestAddUploadChunkCritical(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Push another high priority chunk to trigger the critical.
-	func() {
-		defer func() {
-			if r := recover(); r == nil || !strings.Contains(fmt.Sprint(r), "there should be no buildup if there is nothing in the low priority lane") {
-				t.Fatalf("expected correct critical, got %v", r)
-			}
-		}()
-		ucdq.callAddUploadChunk(chunk(true, 1))
-	}()
-
-	// Wait for the processing thread to be done.
-	err = build.Retry(1000, 10*time.Millisecond, func() error {
-		ucdq.mu.Lock()
-		defer ucdq.mu.Unlock()
-		if !ucdq.processThreadRunning {
-			return nil
-		}
-		return errors.New("processing thread still running")
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Push another chunk. This time it shouldn't panic.
+	// Push a high prio chunk. This should not cause a panic.
 	func() {
 		defer func() {
 			if r := recover(); r != nil {

--- a/modules/renter/uploadchunkdistributionqueue_test.go
+++ b/modules/renter/uploadchunkdistributionqueue_test.go
@@ -1,11 +1,19 @@
 package renter
 
 import (
+	"fmt"
+	"io/ioutil"
+	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 	"unsafe"
 
+	"gitlab.com/NebulousLabs/errors"
+	"go.sia.tech/siad/build"
 	"go.sia.tech/siad/modules"
+	"go.sia.tech/siad/persist"
+	"go.sia.tech/siad/siatest/dependencies"
 )
 
 // newOverloadedWorker will return a worker that is overloaded.
@@ -134,4 +142,85 @@ func TestManagedCheckForUploadWorkers(t *testing.T) {
 	if !finalized {
 		t.Fatal("bad")
 	}
+}
+
+// TestAddUploadChunkCritial is a test that triggers the critical within
+// callAddUploadChunk.
+func TestAddUploadChunkCritical(t *testing.T) {
+	log, _ := persist.NewLogger(ioutil.Discard)
+	r := &Renter{
+		deps: &dependencies.DependencyDelayChunkDistribution{},
+		log:  log,
+	}
+	ucdq := newUploadChunkDistributionQueue(r)
+
+	chunk := func(priority bool, memoryNeeded uint64) *unfinishedUploadChunk {
+		return &unfinishedUploadChunk{
+			staticPriority:     priority,
+			staticMemoryNeeded: memoryNeeded,
+		}
+	}
+
+	// Push low priority chunk with 10 bytes twice. The first one will be
+	// processed right away while the second one will stay in the lane waiting
+	// for the first one to be distributed.
+	ucdq.callAddUploadChunk(chunk(false, 10))
+	ucdq.callAddUploadChunk(chunk(false, 10))
+
+	ucdq.mu.Lock()
+	if ucdq.lowPriorityLane.Len() == 0 {
+		t.Fatal("low prio lane should contain chunks", ucdq.lowPriorityLane.Len())
+	}
+	ucdq.mu.Unlock()
+
+	// Push high priority chunk with 150 bytes. This should bump a low prio
+	// chunk to the high prio lane and leave a non-zero buildup after the first
+	// low prio chunk is distributed.
+	ucdq.callAddUploadChunk(chunk(true, 150))
+
+	// Wait for the low priority lane to empty itself.
+	err := build.Retry(1000, 10*time.Millisecond, func() error {
+		ucdq.mu.Lock()
+		defer ucdq.mu.Unlock()
+		if ucdq.lowPriorityLane.Len() == 0 {
+			return nil
+		}
+		return errors.New("low prio lane not empty")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Push another high priority chunk to trigger the critical.
+	func() {
+		defer func() {
+			if r := recover(); r == nil || !strings.Contains(fmt.Sprint(r), "there should be no buildup if there is nothing in the low priority lane") {
+				t.Fatalf("expected correct critical, got %v", r)
+			}
+		}()
+		ucdq.callAddUploadChunk(chunk(true, 1))
+	}()
+
+	// Wait for the processing thread to be done.
+	err = build.Retry(1000, 10*time.Millisecond, func() error {
+		ucdq.mu.Lock()
+		defer ucdq.mu.Unlock()
+		if !ucdq.processThreadRunning {
+			return nil
+		}
+		return errors.New("processing thread still running")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Push another chunk. This time it shouldn't panic.
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("expected no panic but got %v", r)
+			}
+		}()
+		ucdq.callAddUploadChunk(chunk(true, 1))
+	}()
 }

--- a/siatest/dependencies/dependencies.go
+++ b/siatest/dependencies/dependencies.go
@@ -9,6 +9,11 @@ import (
 )
 
 type (
+	// DependencyDelayChunkDistribution delays the chunk distribution in
+	// callAddUploadChunk by 1 second and skips the actual distribution.
+	DependencyDelayChunkDistribution struct {
+		modules.ProductionDependencies
+	}
 	// DependencyReadRegistryBlocking will block the read registry call by
 	// making it think that it got one more worker than it actually has.
 	// Therefore, waiting for a response that never comes.
@@ -378,6 +383,11 @@ func (d *DependencyDisableWorker) Disrupt(s string) bool {
 		return true
 	}
 	return false
+}
+
+// Disrupt returns true if the correct string is provided.
+func (d *DependencyDelayChunkDistribution) Disrupt(s string) bool {
+	return s == "DelayChunkDistribution"
 }
 
 // Disrupt returns true if the correct string is provided.


### PR DESCRIPTION
This MR is meant to fix the Critical in `uploadchunkdistributionqueue.go` triggering in production.

The first commit adds a test to reproduce the Critical. It turned out that the panic may be triggered simply due to the structure of the locking in `threadedProcessQueue` and that there is no developer error.

That's why the second commit simply removes the sanity check.