### PR TITLE
Add support for pubkeys in registry entry

### DIFF
--- a/modules/host/contractmanager/sectorupdate_test.go
+++ b/modules/host/contractmanager/sectorupdate_test.go
@@ -2099,7 +2099,7 @@ func TestAddVirtualSectorOverflow(t *testing.T) {
 	}
 	loadedOverflow, exists = loaded.Overflow(id)
 	if !exists || loadedOverflow != 0 {
-		t.Fatal("overflow entry should be 0", loadedOverflow)
+		t.Fatal("overflow entry should be 0", loadedOverflow, exists)
 	}
 
 	// Create multiple threads, all adding sectors at the same time.

--- a/modules/host/host.go
+++ b/modules/host/host.go
@@ -791,7 +791,7 @@ func (h *Host) RegistryUpdate(rv modules.SignedRegistryValue, pubKey types.SiaPu
 	if h.dependencies.Disrupt("RegistryUpdateLyingHost") {
 		_, srv, found := h.staticRegistry.Get(modules.DeriveRegistryEntryID(pubKey, rv.Tweak))
 		if found {
-			return srv, registry.ErrSameRevNum
+			return srv, modules.ErrSameRevNum
 		}
 	}
 	// On disrupt, the registry shouldn't be updated.
@@ -847,7 +847,7 @@ func (h *Host) managedInitRegistry() error {
 	}
 
 	// Load the registry.
-	registry, err := registry.New(path, settingsEntries)
+	registry, err := registry.New(path, settingsEntries, h.publicKey)
 	if err != nil {
 		return errors.AddContext(err, "failed to load host registry")
 	}

--- a/modules/host/host_test.go
+++ b/modules/host/host_test.go
@@ -1117,7 +1117,7 @@ func TestHostRegistry(t *testing.T) {
 		spk.Key = pk[:]
 		var tweak crypto.Hash
 		fastrand.Read(tweak[:])
-		rv := modules.NewRegistryValue(tweak, fastrand.Bytes(modules.RegistryDataSize), 0).Sign(sk)
+		rv := modules.NewRegistryValue(tweak, fastrand.Bytes(modules.RegistryEntryDataSize), 0).Sign(sk)
 		_, err := h.RegistryUpdate(rv, spk, 1337)
 		if err != nil {
 			t.Fatal(err)

--- a/modules/host/host_test.go
+++ b/modules/host/host_test.go
@@ -1117,7 +1117,7 @@ func TestHostRegistry(t *testing.T) {
 		spk.Key = pk[:]
 		var tweak crypto.Hash
 		fastrand.Read(tweak[:])
-		rv := modules.NewRegistryValue(tweak, fastrand.Bytes(modules.RegistryEntryDataSize), 0).Sign(sk)
+		rv := modules.NewRegistryValue(tweak, fastrand.Bytes(modules.RegistryDataSize), 0).Sign(sk)
 		_, err := h.RegistryUpdate(rv, spk, 1337)
 		if err != nil {
 			t.Fatal(err)

--- a/modules/host/host_test.go
+++ b/modules/host/host_test.go
@@ -1117,7 +1117,7 @@ func TestHostRegistry(t *testing.T) {
 		spk.Key = pk[:]
 		var tweak crypto.Hash
 		fastrand.Read(tweak[:])
-		rv := modules.NewRegistryValue(tweak, fastrand.Bytes(modules.RegistryDataSize), 0).Sign(sk)
+		rv := modules.NewRegistryValue(tweak, fastrand.Bytes(modules.RegistryDataSize-1), 0).Sign(sk)
 		_, err := h.RegistryUpdate(rv, spk, 1337)
 		if err != nil {
 			t.Fatal(err)

--- a/modules/host/mdm/instructionreadregistry_test.go
+++ b/modules/host/mdm/instructionreadregistry_test.go
@@ -20,7 +20,7 @@ func TestInstructionReadRegistry(t *testing.T) {
 	sk, pk := crypto.GenerateKeyPair()
 	var tweak crypto.Hash
 	fastrand.Read(tweak[:])
-	data := fastrand.Bytes(modules.RegistryEntryDataSize)
+	data := fastrand.Bytes(modules.RegistryDataSize)
 	rev := fastrand.Uint64n(1000)
 	spk := types.SiaPublicKey{
 		Algorithm: types.SignatureEd25519,

--- a/modules/host/mdm/instructionreadregistry_test.go
+++ b/modules/host/mdm/instructionreadregistry_test.go
@@ -20,7 +20,7 @@ func TestInstructionReadRegistry(t *testing.T) {
 	sk, pk := crypto.GenerateKeyPair()
 	var tweak crypto.Hash
 	fastrand.Read(tweak[:])
-	data := fastrand.Bytes(modules.RegistryDataSize)
+	data := fastrand.Bytes(modules.RegistryEntryDataSize)
 	rev := fastrand.Uint64n(1000)
 	spk := types.SiaPublicKey{
 		Algorithm: types.SignatureEd25519,

--- a/modules/host/mdm/instructionreadregistrysid_test.go
+++ b/modules/host/mdm/instructionreadregistrysid_test.go
@@ -22,7 +22,7 @@ func TestInstructionReadRegistryEID(t *testing.T) {
 	sk, pk := crypto.GenerateKeyPair()
 	var tweak crypto.Hash
 	fastrand.Read(tweak[:])
-	data := fastrand.Bytes(modules.RegistryDataSize)
+	data := fastrand.Bytes(modules.RegistryEntryDataSize)
 	rev := fastrand.Uint64n(1000)
 	spk := types.SiaPublicKey{
 		Algorithm: types.SignatureEd25519,
@@ -126,7 +126,7 @@ func TestInstructionReadRegistryEIDNoPubkeyAndTweak(t *testing.T) {
 	sk, pk := crypto.GenerateKeyPair()
 	var tweak crypto.Hash
 	fastrand.Read(tweak[:])
-	data := fastrand.Bytes(modules.RegistryDataSize)
+	data := fastrand.Bytes(modules.RegistryEntryDataSize)
 	rev := fastrand.Uint64n(1000)
 	spk := types.SiaPublicKey{
 		Algorithm: types.SignatureEd25519,

--- a/modules/host/mdm/instructionreadregistrysid_test.go
+++ b/modules/host/mdm/instructionreadregistrysid_test.go
@@ -22,7 +22,7 @@ func TestInstructionReadRegistryEID(t *testing.T) {
 	sk, pk := crypto.GenerateKeyPair()
 	var tweak crypto.Hash
 	fastrand.Read(tweak[:])
-	data := fastrand.Bytes(modules.RegistryEntryDataSize)
+	data := fastrand.Bytes(modules.RegistryDataSize)
 	rev := fastrand.Uint64n(1000)
 	spk := types.SiaPublicKey{
 		Algorithm: types.SignatureEd25519,
@@ -126,7 +126,7 @@ func TestInstructionReadRegistryEIDNoPubkeyAndTweak(t *testing.T) {
 	sk, pk := crypto.GenerateKeyPair()
 	var tweak crypto.Hash
 	fastrand.Read(tweak[:])
-	data := fastrand.Bytes(modules.RegistryEntryDataSize)
+	data := fastrand.Bytes(modules.RegistryDataSize)
 	rev := fastrand.Uint64n(1000)
 	spk := types.SiaPublicKey{
 		Algorithm: types.SignatureEd25519,

--- a/modules/host/mdm/instructionreadregistrysid_test.go
+++ b/modules/host/mdm/instructionreadregistrysid_test.go
@@ -22,7 +22,7 @@ func TestInstructionReadRegistryEID(t *testing.T) {
 	sk, pk := crypto.GenerateKeyPair()
 	var tweak crypto.Hash
 	fastrand.Read(tweak[:])
-	data := fastrand.Bytes(modules.RegistryDataSize)
+	data := fastrand.Bytes(modules.RegistryDataSize - 1)
 	rev := fastrand.Uint64n(1000)
 	spk := types.SiaPublicKey{
 		Algorithm: types.SignatureEd25519,
@@ -126,7 +126,7 @@ func TestInstructionReadRegistryEIDNoPubkeyAndTweak(t *testing.T) {
 	sk, pk := crypto.GenerateKeyPair()
 	var tweak crypto.Hash
 	fastrand.Read(tweak[:])
-	data := fastrand.Bytes(modules.RegistryDataSize)
+	data := fastrand.Bytes(modules.RegistryDataSize - 1)
 	rev := fastrand.Uint64n(1000)
 	spk := types.SiaPublicKey{
 		Algorithm: types.SignatureEd25519,

--- a/modules/host/mdm/instructionupdateregistry.go
+++ b/modules/host/mdm/instructionupdateregistry.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"fmt"
 
+	"gitlab.com/NebulousLabs/errors"
 	"go.sia.tech/siad/modules"
 	"go.sia.tech/siad/types"
 )
@@ -91,10 +92,10 @@ func (i *instructionUpdateRegistry) Execute(prevOutput output) (output, types.Cu
 	// Add 1 year to the expiry.
 	newExpiry := i.staticState.host.BlockHeight() + types.BlocksPerYear
 
-	// Create registry value and validate its data.
+	// Create registry value and validate its version.
 	rv := modules.NewSignedRegistryValue(tweak, data, revision, signature)
-	if err := rv.ValidateData(); err != nil {
-		return errOutput(err), types.ZeroCurrency
+	if rv.Version() == modules.RegistryEntryVersionInvalid {
+		return errOutput(errors.New("invalid registry entry version")), types.ZeroCurrency
 	}
 
 	// Try updating the registry.

--- a/modules/host/mdm/instructionupdateregistry_test.go
+++ b/modules/host/mdm/instructionupdateregistry_test.go
@@ -76,7 +76,8 @@ func TestInstructionUpdateRegistry(t *testing.T) {
 	// data to make sure the longer entry also works.
 	tb = newTestProgramBuilder(pt, 0)
 	rv.Revision++
-	rv.Data = append(rv.Data, pk[:]...)
+	spkh := crypto.HashObject(spk)
+	rv.Data = append(rv.Data, spkh[:]...)
 	rv = rv.Sign(sk)
 	tb.AddUpdateRegistryInstruction(spk, rv)
 	outputs, err = mdm.ExecuteProgramWithBuilder(tb, so, 0, false)

--- a/modules/host/mdm/mdm_test.go
+++ b/modules/host/mdm/mdm_test.go
@@ -13,7 +13,6 @@ import (
 	"gitlab.com/NebulousLabs/fastrand"
 	"go.sia.tech/siad/crypto"
 	"go.sia.tech/siad/modules"
-	"go.sia.tech/siad/modules/host/registry"
 	"go.sia.tech/siad/types"
 )
 
@@ -102,10 +101,10 @@ func (h *TestHost) RegistryUpdate(rv modules.SignedRegistryValue, pubKey types.S
 	oldRV, exists := h.registry[key]
 
 	if exists && rv.Revision < oldRV.Revision {
-		return oldRV.SignedRegistryValue, registry.ErrLowerRevNum
+		return oldRV.SignedRegistryValue, modules.ErrLowerRevNum
 	}
 	if exists && rv.Revision == oldRV.Revision {
-		return oldRV.SignedRegistryValue, registry.ErrSameRevNum
+		return oldRV.SignedRegistryValue, modules.ErrSameRevNum
 	}
 
 	h.registry[key] = TestRegistryValue{
@@ -329,7 +328,7 @@ func (o Output) assert(newSize uint64, newMerkleRoot crypto.Hash, proof []crypto
 	} else if err == nil && o.Error != nil {
 		return fmt.Errorf("output contained error: %v", o.Error)
 	} else if o.Error != nil && err != nil && o.Error.Error() != err.Error() {
-		return fmt.Errorf("output errors don't match %v != %v", o.Error, err)
+		return fmt.Errorf("output errors don't match: %v != %v", o.Error, err)
 	}
 	if o.NewSize != newSize {
 		return fmt.Errorf("expected newSize %v but got %v", newSize, o.NewSize)

--- a/modules/host/registry/persist_test.go
+++ b/modules/host/registry/persist_test.go
@@ -28,9 +28,10 @@ func randomValue(index int64) (modules.SignedRegistryValue, *value, crypto.Secre
 	v := value{
 		expiry:      types.BlockHeight(fastrand.Uint64n(math.MaxUint32)),
 		staticIndex: index,
-		data:        fastrand.Bytes(modules.RegistryDataSize),
+		data:        fastrand.Bytes(modules.RegistryDataSize - 1),
 		revision:    fastrand.Uint64n(math.MaxUint64 - 100), // Leave some room for incrementing the revision during tests
 	}
+	v.data[len(v.data)-1] = modules.RegistryEntryVersionNoPubKey
 	v.key.Algorithm = types.SignatureEd25519
 	v.key.Key = pk[:]
 	fastrand.Read(v.tweak[:])

--- a/modules/host/registry/persist_test.go
+++ b/modules/host/registry/persist_test.go
@@ -240,7 +240,7 @@ func TestSaveEntry(t *testing.T) {
 
 	// Create a new registry.
 	registryPath := filepath.Join(dir, "registry")
-	r, err := New(registryPath, testingDefaultMaxEntries)
+	r, err := New(registryPath, testingDefaultMaxEntries, types.SiaPublicKey{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/host/registry/persist_test.go
+++ b/modules/host/registry/persist_test.go
@@ -28,7 +28,7 @@ func randomValue(index int64) (modules.SignedRegistryValue, *value, crypto.Secre
 	v := value{
 		expiry:      types.BlockHeight(fastrand.Uint64n(math.MaxUint32)),
 		staticIndex: index,
-		data:        fastrand.Bytes(modules.RegistryEntryDataSize),
+		data:        fastrand.Bytes(modules.RegistryDataSize),
 		revision:    fastrand.Uint64n(math.MaxUint64 - 100), // Leave some room for incrementing the revision during tests
 	}
 	v.key.Algorithm = types.SignatureEd25519

--- a/modules/host/registry/persist_test.go
+++ b/modules/host/registry/persist_test.go
@@ -28,7 +28,7 @@ func randomValue(index int64) (modules.SignedRegistryValue, *value, crypto.Secre
 	v := value{
 		expiry:      types.BlockHeight(fastrand.Uint64n(math.MaxUint32)),
 		staticIndex: index,
-		data:        fastrand.Bytes(fastrand.Intn(modules.RegistryDataSize) + 1),
+		data:        fastrand.Bytes(modules.RegistryEntryDataSize),
 		revision:    fastrand.Uint64n(math.MaxUint64 - 100), // Leave some room for incrementing the revision during tests
 	}
 	v.key.Algorithm = types.SignatureEd25519

--- a/modules/host/registry/registry.go
+++ b/modules/host/registry/registry.go
@@ -23,16 +23,6 @@ const (
 	PersistedEntrySize = modules.RegistryEntrySize
 )
 
-const (
-	// RegistryEntryNoPubKeySize is the expected size of a registry entry
-	// without a pubkey.
-	RegistryEntryNoPubKeySize = 34
-
-	// RegistryEntryWithPubKeySize is the expectedsize of a registry entry with
-	// a pubkey.
-	RegistryEntryWithPubKeySize = RegistryEntryNoPubKeySize + crypto.HashSize
-)
-
 var (
 	// errEntryWrongSize is returned when a marshaled entry doesn't have a size
 	// of persistedEntrySize. This should never happen.

--- a/modules/host/registry/registry.go
+++ b/modules/host/registry/registry.go
@@ -277,6 +277,7 @@ func New(path string, maxEntries uint64, hpk types.SiaPublicKey) (_ *Registry, e
 	}
 	// Create the registry.
 	reg := &Registry{
+		staticHPK:  hpk,
 		staticFile: f,
 		staticPath: path,
 		usage:      b,

--- a/modules/host/registry/registry.go
+++ b/modules/host/registry/registry.go
@@ -30,7 +30,7 @@ const (
 
 	// RegistryEntryWithPubKeySize is the expectedsize of a registry entry with
 	// a pubkey.
-	RegistryEntryWithPubKeySize = RegistryEntryNoPubKeySize + crypto.PublicKeySize
+	RegistryEntryWithPubKeySize = RegistryEntryNoPubKeySize + crypto.HashSize
 )
 
 var (

--- a/modules/host/registry/registry_test.go
+++ b/modules/host/registry/registry_test.go
@@ -834,13 +834,7 @@ func TestRegistryRace(t *testing.T) {
 			exp := types.BlockHeight(atomic.AddUint64(nextExpiry, 1))
 			rv = rv.Sign(sk)
 			_, err := r.Update(rv, key, exp)
-			if errors.Contains(err, modules.ErrSameRevNum) {
-				continue // invalid revision numbers are expected
-			}
-			if errors.Contains(err, modules.ErrLowerRevNum) {
-				continue // invalid revision numbers are expected
-			}
-			if errors.Contains(err, errInvalidEntry) {
+			if modules.IsLowerPrioEntryErr(err) {
 				continue // invalid entries are expected
 			}
 			if err != nil {

--- a/modules/host/registry/registry_test.go
+++ b/modules/host/registry/registry_test.go
@@ -275,7 +275,8 @@ func TestUpdate(t *testing.T) {
 	// Update the key again. This time with the same revision and PoW but a
 	// matching hostpubkey. This should work.
 	expectedRV = rv
-	rv.Data = append(rv.Data, pk[:]...)
+	spkh := crypto.HashObject(spk)
+	rv.Data = append(rv.Data, spkh[:]...)
 	rv = rv.Sign(sk)
 	v.data = rv.Data
 	v.signature = rv.Signature

--- a/modules/host/registry/registry_test.go
+++ b/modules/host/registry/registry_test.go
@@ -835,6 +835,9 @@ func TestRegistryRace(t *testing.T) {
 			rv = rv.Sign(sk)
 			_, err := r.Update(rv, key, exp)
 			if modules.IsLowerPrioEntryErr(err) {
+				continue // lower prio entries are expected
+			}
+			if errors.Contains(err, errInvalidEntry) {
 				continue // invalid entries are expected
 			}
 			if err != nil {

--- a/modules/host/registry/registry_test.go
+++ b/modules/host/registry/registry_test.go
@@ -257,7 +257,7 @@ func TestUpdate(t *testing.T) {
 	// should work.
 	expectedRV = rv
 	for !rv.HasMoreWork(expectedRV.RegistryValue) {
-		rv.Data = fastrand.Bytes(modules.RegistryEntryDataSize)
+		rv.Data = fastrand.Bytes(modules.RegistryDataSize)
 		rv = rv.Sign(sk)
 		v.data = rv.Data
 		v.signature = rv.Signature

--- a/modules/host/registry/registry_test.go
+++ b/modules/host/registry/registry_test.go
@@ -257,30 +257,11 @@ func TestUpdate(t *testing.T) {
 	// should work.
 	expectedRV = rv
 	for !rv.HasMoreWork(expectedRV.RegistryValue) {
-		rv.Data = fastrand.Bytes(modules.RegistryDataSize)
+		rv.Data = fastrand.Bytes(modules.RegistryDataSize - 1)
 		rv = rv.Sign(sk)
 		v.data = rv.Data
 		v.signature = rv.Signature
 	}
-	oldRV, err = r.Update(rv, v.key, v.expiry)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !reflect.DeepEqual(oldRV, expectedRV) {
-		t.Log(oldRV)
-		t.Log(expectedRV)
-		t.Fatal("wrong oldRV returned")
-	}
-
-	// Update the key again. This time with the same revision and PoW but a
-	// matching hostpubkey. This should work.
-	expectedRV = rv
-	spkh := crypto.HashObject(spk)
-	rv.Data = append(rv.Data, spkh[:]...)
-	rv = rv.Sign(sk)
-	v.data = rv.Data
-	v.signature = rv.Signature
-
 	oldRV, err = r.Update(rv, v.key, v.expiry)
 	if err != nil {
 		t.Fatal(err)

--- a/modules/host/registry/registry_test.go
+++ b/modules/host/registry/registry_test.go
@@ -244,7 +244,7 @@ func TestUpdate(t *testing.T) {
 	// same and the PoW is the same.
 	expectedRV := rv
 	oldRV, err = r.Update(rv, v.key, v.expiry)
-	if !errors.Contains(err, modules.ErrSameRevNum) {
+	if !errors.Contains(err, modules.ErrSameEntry) {
 		t.Fatal("expected invalid rev number", err)
 	}
 	if !reflect.DeepEqual(oldRV, expectedRV) {

--- a/modules/host/rpcexecuteprogram_test.go
+++ b/modules/host/rpcexecuteprogram_test.go
@@ -18,7 +18,6 @@ import (
 	"go.sia.tech/siad/build"
 	"go.sia.tech/siad/crypto"
 	"go.sia.tech/siad/modules"
-	"go.sia.tech/siad/modules/host/registry"
 	"go.sia.tech/siad/siatest/dependencies"
 	"go.sia.tech/siad/types"
 )
@@ -1352,7 +1351,7 @@ func TestExecuteUpdateRegistryProgram(t *testing.T) {
 	resp = resps[0]
 
 	// Check response.
-	if resp.Error == nil || !strings.Contains(resp.Error.Error(), registry.ErrSameRevNum.Error()) {
+	if resp.Error == nil || !strings.Contains(resp.Error.Error(), modules.ErrSameRevNum.Error()) {
 		t.Fatal(resp.Error)
 	}
 	if !resp.AdditionalCollateral.Equals(collateral) {
@@ -1424,7 +1423,7 @@ func TestExecuteUpdateRegistryProgram(t *testing.T) {
 	resp = resps[0]
 
 	// Check response.
-	if resp.Error == nil || !strings.Contains(resp.Error.Error(), registry.ErrLowerRevNum.Error()) {
+	if resp.Error == nil || !strings.Contains(resp.Error.Error(), modules.ErrLowerRevNum.Error()) {
 		t.Fatal(resp.Error)
 	}
 	if !resp.AdditionalCollateral.Equals(collateral) {

--- a/modules/host/rpcexecuteprogram_test.go
+++ b/modules/host/rpcexecuteprogram_test.go
@@ -1244,7 +1244,7 @@ func TestExecuteUpdateRegistryProgram(t *testing.T) {
 	// Create a signed registry value.
 	sk, pk := crypto.GenerateKeyPair()
 	tweak := crypto.Hash{1, 2, 3}
-	data := fastrand.Bytes(modules.RegistryDataSize)
+	data := fastrand.Bytes(modules.RegistryEntryDataSize)
 	rev := uint64(1)
 	rv := modules.NewRegistryValue(tweak, data, rev).Sign(sk)
 	spk := types.SiaPublicKey{
@@ -1501,7 +1501,7 @@ func TestExecuteReadRegistryProgram(t *testing.T) {
 	// Create a signed registry value.
 	sk, pk := crypto.GenerateKeyPair()
 	tweak := crypto.Hash{1, 2, 3}
-	data := fastrand.Bytes(modules.RegistryDataSize)
+	data := fastrand.Bytes(modules.RegistryEntryDataSize)
 	rev := uint64(0)
 	rv := modules.NewRegistryValue(tweak, data, rev).Sign(sk)
 	spk := types.SiaPublicKey{

--- a/modules/host/rpcexecuteprogram_test.go
+++ b/modules/host/rpcexecuteprogram_test.go
@@ -1244,7 +1244,7 @@ func TestExecuteUpdateRegistryProgram(t *testing.T) {
 	// Create a signed registry value.
 	sk, pk := crypto.GenerateKeyPair()
 	tweak := crypto.Hash{1, 2, 3}
-	data := fastrand.Bytes(modules.RegistryEntryDataSize)
+	data := fastrand.Bytes(modules.RegistryDataSize)
 	rev := uint64(1)
 	rv := modules.NewRegistryValue(tweak, data, rev).Sign(sk)
 	spk := types.SiaPublicKey{
@@ -1501,7 +1501,7 @@ func TestExecuteReadRegistryProgram(t *testing.T) {
 	// Create a signed registry value.
 	sk, pk := crypto.GenerateKeyPair()
 	tweak := crypto.Hash{1, 2, 3}
-	data := fastrand.Bytes(modules.RegistryEntryDataSize)
+	data := fastrand.Bytes(modules.RegistryDataSize)
 	rev := uint64(0)
 	rv := modules.NewRegistryValue(tweak, data, rev).Sign(sk)
 	spk := types.SiaPublicKey{

--- a/modules/host/rpcexecuteprogram_test.go
+++ b/modules/host/rpcexecuteprogram_test.go
@@ -1244,7 +1244,7 @@ func TestExecuteUpdateRegistryProgram(t *testing.T) {
 	// Create a signed registry value.
 	sk, pk := crypto.GenerateKeyPair()
 	tweak := crypto.Hash{1, 2, 3}
-	data := fastrand.Bytes(modules.RegistryDataSize)
+	data := fastrand.Bytes(modules.RegistryDataSize - 1)
 	rev := uint64(1)
 	rv := modules.NewRegistryValue(tweak, data, rev).Sign(sk)
 	spk := types.SiaPublicKey{
@@ -1501,7 +1501,7 @@ func TestExecuteReadRegistryProgram(t *testing.T) {
 	// Create a signed registry value.
 	sk, pk := crypto.GenerateKeyPair()
 	tweak := crypto.Hash{1, 2, 3}
-	data := fastrand.Bytes(modules.RegistryDataSize)
+	data := fastrand.Bytes(modules.RegistryDataSize - 1)
 	rev := uint64(0)
 	rv := modules.NewRegistryValue(tweak, data, rev).Sign(sk)
 	spk := types.SiaPublicKey{
@@ -1582,9 +1582,9 @@ func TestExecuteReadRegistryProgram(t *testing.T) {
 	if len(resp.Proof) != 0 {
 		t.Fatalf("wrong Proof %v != %v", resp.Proof, []crypto.Hash{})
 	}
-	if len(resp.Output) != 106 {
-		// 106 = 64 (sig) + 8 (revision) + 34 (data)
-		t.Fatalf("wrong Output length %v != %v", len(resp.Output), 185)
+	if len(resp.Output) != 184 {
+		// 184 = 64 (sig) + 8 (revision) + 112 (data)
+		t.Fatalf("wrong Output length %v != %v", len(resp.Output), 184)
 	}
 	if !resp.TotalCost.Equals(programCost) {
 		t.Fatalf("wrong TotalCost %v != %v", resp.TotalCost.HumanString(), programCost.HumanString())

--- a/modules/host/rpcexecuteprogram_test.go
+++ b/modules/host/rpcexecuteprogram_test.go
@@ -1351,7 +1351,7 @@ func TestExecuteUpdateRegistryProgram(t *testing.T) {
 	resp = resps[0]
 
 	// Check response.
-	if resp.Error == nil || !strings.Contains(resp.Error.Error(), modules.ErrSameRevNum.Error()) {
+	if resp.Error == nil || !strings.Contains(resp.Error.Error(), modules.ErrSameEntry.Error()) {
 		t.Fatal(resp.Error)
 	}
 	if !resp.AdditionalCollateral.Equals(collateral) {
@@ -1582,8 +1582,8 @@ func TestExecuteReadRegistryProgram(t *testing.T) {
 	if len(resp.Proof) != 0 {
 		t.Fatalf("wrong Proof %v != %v", resp.Proof, []crypto.Hash{})
 	}
-	if len(resp.Output) != 185 {
-		// 185 = 64 (sig) + 8 (revision) + 113 (data)
+	if len(resp.Output) != 106 {
+		// 106 = 64 (sig) + 8 (revision) + 34 (data)
 		t.Fatalf("wrong Output length %v != %v", len(resp.Output), 185)
 	}
 	if !resp.TotalCost.Equals(programCost) {

--- a/modules/host/rpcsubscribe_test.go
+++ b/modules/host/rpcsubscribe_test.go
@@ -35,11 +35,6 @@ func randomRegistryValue() (modules.SignedRegistryValue, types.SiaPublicKey, cry
 		Algorithm: types.SignatureEd25519,
 		Key:       pk[:],
 	}
-	if fastrand.Intn(2) == 0 {
-		// Random chance to add a pubkey.
-		spkh := crypto.HashObject(spk)
-		data = append(data, spkh[:]...)
-	}
 	rv := modules.NewRegistryValue(tweak, data, rev).Sign(sk)
 	return rv, spk, sk
 }

--- a/modules/host/rpcsubscribe_test.go
+++ b/modules/host/rpcsubscribe_test.go
@@ -29,6 +29,7 @@ func randomRegistryValue() (modules.SignedRegistryValue, types.SiaPublicKey, cry
 	var tweak crypto.Hash
 	fastrand.Read(tweak[:])
 	data := fastrand.Bytes(modules.RegistryDataSize)
+	data[len(data)-1] = modules.RegistryEntryVersionNoPubKey
 	rev := fastrand.Uint64n(1000)
 	spk := types.SiaPublicKey{
 		Algorithm: types.SignatureEd25519,

--- a/modules/host/rpcsubscribe_test.go
+++ b/modules/host/rpcsubscribe_test.go
@@ -28,7 +28,7 @@ func randomRegistryValue() (modules.SignedRegistryValue, types.SiaPublicKey, cry
 	sk, pk := crypto.GenerateKeyPair()
 	var tweak crypto.Hash
 	fastrand.Read(tweak[:])
-	data := fastrand.Bytes(modules.RegistryEntryDataSize)
+	data := fastrand.Bytes(modules.RegistryDataSize)
 	rev := fastrand.Uint64n(1000)
 	spk := types.SiaPublicKey{
 		Algorithm: types.SignatureEd25519,

--- a/modules/host/rpcsubscribe_test.go
+++ b/modules/host/rpcsubscribe_test.go
@@ -28,11 +28,16 @@ func randomRegistryValue() (modules.SignedRegistryValue, types.SiaPublicKey, cry
 	sk, pk := crypto.GenerateKeyPair()
 	var tweak crypto.Hash
 	fastrand.Read(tweak[:])
-	data := fastrand.Bytes(modules.RegistryDataSize)
+	data := fastrand.Bytes(modules.RegistryEntryDataSize)
 	rev := fastrand.Uint64n(1000)
 	spk := types.SiaPublicKey{
 		Algorithm: types.SignatureEd25519,
 		Key:       pk[:],
+	}
+	if fastrand.Intn(2) == 0 {
+		// Random chance to add a pubkey.
+		spkh := crypto.HashObject(spk)
+		data = append(data, spkh[:]...)
 	}
 	rv := modules.NewRegistryValue(tweak, data, rev).Sign(sk)
 	return rv, spk, sk

--- a/modules/host/rpcupdatepricetable_test.go
+++ b/modules/host/rpcupdatepricetable_test.go
@@ -204,7 +204,7 @@ func testUpdatePriceTableBasic(t *testing.T, rhp *renterHostPair) {
 		spk.Key = pk[:]
 		var tweak crypto.Hash
 		fastrand.Read(tweak[:])
-		rv := modules.NewRegistryValue(tweak, fastrand.Bytes(modules.RegistryDataSize), 0).Sign(sk)
+		rv := modules.NewRegistryValue(tweak, fastrand.Bytes(modules.RegistryDataSize-1), 0).Sign(sk)
 		_, err := host.RegistryUpdate(rv, spk, 1337)
 		if err != nil {
 			t.Fatal(err)

--- a/modules/host/rpcupdatepricetable_test.go
+++ b/modules/host/rpcupdatepricetable_test.go
@@ -204,7 +204,7 @@ func testUpdatePriceTableBasic(t *testing.T, rhp *renterHostPair) {
 		spk.Key = pk[:]
 		var tweak crypto.Hash
 		fastrand.Read(tweak[:])
-		rv := modules.NewRegistryValue(tweak, fastrand.Bytes(modules.RegistryEntryDataSize), 0).Sign(sk)
+		rv := modules.NewRegistryValue(tweak, fastrand.Bytes(modules.RegistryDataSize), 0).Sign(sk)
 		_, err := host.RegistryUpdate(rv, spk, 1337)
 		if err != nil {
 			t.Fatal(err)

--- a/modules/host/rpcupdatepricetable_test.go
+++ b/modules/host/rpcupdatepricetable_test.go
@@ -204,7 +204,7 @@ func testUpdatePriceTableBasic(t *testing.T, rhp *renterHostPair) {
 		spk.Key = pk[:]
 		var tweak crypto.Hash
 		fastrand.Read(tweak[:])
-		rv := modules.NewRegistryValue(tweak, fastrand.Bytes(modules.RegistryDataSize), 0).Sign(sk)
+		rv := modules.NewRegistryValue(tweak, fastrand.Bytes(modules.RegistryEntryDataSize), 0).Sign(sk)
 		_, err := host.RegistryUpdate(rv, spk, 1337)
 		if err != nil {
 			t.Fatal(err)

--- a/modules/mdm.go
+++ b/modules/mdm.go
@@ -123,6 +123,12 @@ const (
 	// pubKeyLength + dataOffset + dataLength = 7 * 8 bytes = 56 byte
 	RPCIUpdateRegistryLen = 56
 
+	// RPCIUpdateRegistryLenWithVersion is the expected length of the 'Args' of
+	// an UpdateRegistry instruction with version byte.  tweakOffset +
+	// revisionOffset + signatureOffset + pubKeyOffset + pubKeyLength +
+	// dataOffset + dataLength = 7 * 8 bytes + version = 57 byte
+	RPCIUpdateRegistryLenWithVersion = 57
+
 	// RPCIReadRegistryLen is the expected length of the 'Args' of an
 	// ReadRegistry instruction.
 	// tweakOffset + pubKeyOffset + pubKeyLength = 3 * 8 bytes = 24 byte

--- a/modules/registry.go
+++ b/modules/registry.go
@@ -235,9 +235,11 @@ func (entry RegistryValue) hash() crypto.Hash {
 // work returns the work of the registry value.
 func (entry RegistryValue) work() crypto.Hash {
 	data := entry.Data
-	// For entries with pubkeys, ignore the pubkey at the beginning.
+	// For entries with pubkeys, ignore the pubkey at the beginning and the
+	// version at the end. That way a legacy entry containing the same data as
+	// an entry with version byte will still have the same work.
 	if entry.Version() == RegistryEntryVersionWithPubKey {
-		data = data[HostPubKeyHashSize:]
+		data = data[HostPubKeyHashSize : len(data)-1]
 	}
 	return crypto.HashAll(entry.Tweak, data, entry.Revision)
 }

--- a/modules/registry.go
+++ b/modules/registry.go
@@ -2,8 +2,11 @@ package modules
 
 import (
 	"bytes"
+	"fmt"
 
+	"gitlab.com/NebulousLabs/errors"
 	"go.sia.tech/siad/crypto"
+	"go.sia.tech/siad/types"
 )
 
 const (
@@ -24,6 +27,37 @@ const (
 
 	// FileIDVersion is the current version we expect in a FileID.
 	FileIDVersion = 1
+)
+
+const (
+	// RegistryEntryDataSize is the expected size of a registry update without a
+	// pubkey.
+	RegistryEntryDataSize = 34
+
+	// RegistryEntryDataSizeWithPubKey is the expected size of a registry update
+	// with a pubkey.
+	RegistryEntryDataSizeWithPubKey = RegistryEntryDataSize + crypto.PublicKeySize
+)
+
+var (
+	// ErrLowerRevNum is returned when the revision number of the data to
+	// register isn't greater than the known revision number.
+	ErrLowerRevNum = errors.New("provided revision number is invalid")
+	// ErrSameRevNum is returned if the revision number of the data to register
+	// is already registered and the work is insufficient to overwrite the
+	// revision.
+	ErrSameRevNum = errors.New("provided revision number is already registered")
+	// ErrSameWork is returned when an entry can't be updated because both
+	// revision and work are the same and the new entry can't be prioritized
+	// based on its pubkey.
+	ErrSameWork = errors.New("provided registry update has same amount of work as previous one")
+	// ErrSameEntry is returned if the entry can't be updated and is considered
+	// equal to the existing entry based on its revision number, work and
+	// pubkey.
+	ErrSameEntry = errors.New("provided registry update and old update are either both primary updates or both secondary updates")
+	// ErrUnexpectedEntryLength is returned when an operation fails due to the
+	// registry entry containing an unexpted amount of data.
+	ErrUnexpectedEntryLength = fmt.Errorf("unexpected entry length, expect %v or %v", RegistryEntryDataSize, RegistryEntryDataSizeWithPubKey)
 )
 
 // RoundRegistrySize is a helper to correctly round up the size of a registry to
@@ -54,11 +88,12 @@ type SignedRegistryValue struct {
 // NewRegistryValue is a convenience method for creating a new RegistryValue
 // from arguments.
 func NewRegistryValue(tweak crypto.Hash, data []byte, rev uint64) RegistryValue {
-	return RegistryValue{
-		Tweak:    tweak,
+	rv := RegistryValue{
 		Data:     append([]byte{}, data...), // deep copy data to prevent races
+		Tweak:    tweak,
 		Revision: rev,
 	}
+	return rv
 }
 
 // NewSignedRegistryValue is a convenience method for creating a new
@@ -79,11 +114,74 @@ func (entry RegistryValue) Sign(sk crypto.SecretKey) SignedRegistryValue {
 	}
 }
 
+// IsLowerPrioEntryErr indicates whether an error was caused by a registry entry
+// not having sufficient priority to be overwritten.
+func IsLowerPrioEntryErr(err error) bool {
+	return errors.Contains(err, ErrLowerRevNum) || errors.Contains(err,
+		ErrSameRevNum) || errors.Contains(err, ErrSameWork) || errors.Contains(err,
+		ErrSameEntry)
+}
+
 // HasMoreWork returns 'true' if the hash of entry is larger than target's.
 func (entry RegistryValue) HasMoreWork(target RegistryValue) bool {
-	hEntry := entry.hash()
-	hTarget := target.hash()
+	hEntry := entry.work()
+	hTarget := target.work()
 	return bytes.Compare(hTarget[:], hEntry[:]) > 0
+}
+
+// CanUpdateWith checks whether entry can be overwritten by entry2 based on its
+// revision numbers, work and pubkey.
+func (entry RegistryValue) CanUpdateWith(entry2 RegistryValue, hpk types.SiaPublicKey) error {
+	if entry.Revision > entry2.Revision {
+		return ErrLowerRevNum
+	} else if entry2.Revision > entry.Revision {
+		return nil
+	}
+	if entry.HasMoreWork(entry2) {
+		return ErrSameRevNum
+	} else if entry2.HasMoreWork(entry) {
+		return nil
+	}
+	entryHPK, err := entry.ParsePubKey()
+	if err != nil {
+		return err
+	}
+	entry2HPK, err := entry2.ParsePubKey()
+	if err != nil {
+		return err
+	}
+	entryIsOnHost := entryHPK != nil && entryHPK.Equals(hpk)
+	entry2IsOnHost := entry2HPK != nil && entry2HPK.Equals(hpk)
+	if entryIsOnHost && !entry2IsOnHost {
+		return ErrSameWork
+	} else if entry2IsOnHost && !entryIsOnHost {
+		return nil
+	}
+	return ErrSameEntry
+}
+
+// ValidateData validates the payload of an entry.
+func (entry RegistryValue) ValidateData() error {
+	if len(entry.Data) != RegistryEntryDataSize && len(entry.Data) != RegistryEntryDataSizeWithPubKey {
+		return ErrUnexpectedEntryLength
+	}
+	return nil
+}
+
+// ParsePubKey tries to parse a pubkey from a registry entry. It returns `nil`
+// if no key is found.
+func (entry RegistryValue) ParsePubKey() (*types.SiaPublicKey, error) {
+	switch len(entry.Data) {
+	case RegistryEntryDataSize:
+		return nil, nil
+	case RegistryEntryDataSizeWithPubKey:
+		var pk crypto.PublicKey
+		copy(pk[:], entry.Data[RegistryEntryDataSize:])
+		spk := types.Ed25519PublicKey(pk)
+		return &spk, nil
+	default:
+	}
+	return nil, ErrUnexpectedEntryLength
 }
 
 // Verify verifies the signature on the RegistryValue.
@@ -95,4 +193,14 @@ func (entry SignedRegistryValue) Verify(pk crypto.PublicKey) error {
 // hash hashes the registry value.
 func (entry RegistryValue) hash() crypto.Hash {
 	return crypto.HashAll(entry.Tweak, entry.Data, entry.Revision)
+}
+
+// work returns the work of the registry value.
+func (entry RegistryValue) work() crypto.Hash {
+	data := entry.Data
+	// For entries with pubkeys, ignore the pubkey.
+	if len(data) == RegistryEntryDataSizeWithPubKey {
+		data = data[:RegistryEntryDataSize]
+	}
+	return crypto.HashAll(entry.Tweak, data, entry.Revision)
 }

--- a/modules/registry_test.go
+++ b/modules/registry_test.go
@@ -38,7 +38,8 @@ func TestCanUpdateWith(t *testing.T) {
 
 	// Value with matching pubkey.
 	rvPubKey := rv
-	rvPubKey.Data = append(rvPubKey.Data, pk[:]...)
+	spkh := crypto.HashObject(spk)
+	rvPubKey.Data = append(rvPubKey.Data, spkh[:]...)
 
 	// Run multiple testcases.
 	tests := []struct {

--- a/modules/registry_test.go
+++ b/modules/registry_test.go
@@ -16,11 +16,11 @@ import (
 func TestCanUpdateWith(t *testing.T) {
 	t.Parallel()
 
-	rvData, err := hex.DecodeString("829675d476f4795e5e3caf6583d1f323a8f065236b9ace5296dfd6b24c876ba7f135")
+	rvData, err := hex.DecodeString("732e473d43831439cc0e9afe560a0e666868cfe66eac19ab53235fcb5e4e9222e72f499a8fc9bd9d8d2b66c9f6eba266e3017297b7b7a1898415f7ab44b4e48b64f5e594bd27400442ed608cb336d80463cfefcd089f62401f3e6ae4")
 	if err != nil {
 		t.Fatal(err)
 	}
-	rvMoreWorkData, err := hex.DecodeString("0673b5a673596d840db8f714bbf6751e7d1869fca23e67fa20803597f925ac45e445")
+	rvMoreWorkData, err := hex.DecodeString("a9acd0b5be0acd08e67ab53637d9b7ae0f82e354f9cf0aa615bc5c6a77a05f315b042131358aa18c1978a574f2b1ea80d5ad8f5d441aa490583f2f790c348b5c102ce6f161fa2df6cb713fbe11b57c9a9cbe274534077afba0184ae26fb9d59d2983aad92cd8c6949c548cb81491d060b4")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -37,9 +37,13 @@ func TestCanUpdateWith(t *testing.T) {
 	rvHigherRev := rv
 	rvHigherRev.Revision++
 
-	// Value with matching pubkey.
+	// Create value with pubkey and 10 byte payload.
 	rvPubKey := NewRegistryValueWithPubKey(rv.Tweak, spk, fastrand.Bytes(10), rv.Revision)
-	rvNoPubKey := NewRegistryValue(rv.Tweak, rvPubKey.Data[HostPubKeyHashSize:], rv.Revision)
+
+	// Create a version 1 entry by copying the payload without the pubkey and
+	// version byte. This entry should have the same work now as rvPubKey.
+	d := append([]byte{}, rvPubKey.Data[:len(rvPubKey.Data)-1]...)
+	rvNoPubKey := NewRegistryValue(rv.Tweak, d[HostPubKeyHashSize:], rv.Revision)
 
 	// Run multiple testcases.
 	tests := []struct {

--- a/modules/registry_test.go
+++ b/modules/registry_test.go
@@ -5,13 +5,103 @@ import (
 	"math"
 	"testing"
 
+	"gitlab.com/NebulousLabs/errors"
 	"gitlab.com/NebulousLabs/fastrand"
 	"go.sia.tech/siad/crypto"
+	"go.sia.tech/siad/types"
 )
+
+// TestCanUpdateWith is a unit test for CanUpdateWith.
+func TestCanUpdateWith(t *testing.T) {
+	t.Parallel()
+
+	rvData, err := hex.DecodeString("829675d476f4795e5e3caf6583d1f323a8f065236b9ace5296dfd6b24c876ba7f135")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rvMoreWorkData, err := hex.DecodeString("0673b5a673596d840db8f714bbf6751e7d1869fca23e67fa20803597f925ac45e445")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, pk := crypto.GenerateKeyPair()
+	spk := types.Ed25519PublicKey(pk)
+
+	// Base value.
+	rv := NewRegistryValue(crypto.Hash{}, rvData, 0)
+
+	// Value with more work than base.
+	rvMoreWork := NewRegistryValue(crypto.Hash{}, rvMoreWorkData, 0)
+
+	// Value with higher revision than base.
+	rvHigherRev := rv
+	rvHigherRev.Revision++
+
+	// Value with matching pubkey.
+	rvPubKey := rv
+	rvPubKey.Data = append(rvPubKey.Data, pk[:]...)
+
+	// Run multiple testcases.
+	tests := []struct {
+		old RegistryValue
+		new RegistryValue
+		err error
+	}{
+		// Case 0: update base with itself
+		{
+			old: rv,
+			new: rv,
+			err: ErrSameEntry,
+		},
+		// Case 1: update base with higher rev
+		{
+			old: rv,
+			new: rvHigherRev,
+			err: nil,
+		},
+		// Case 2: update higher rev with lower base
+		{
+			old: rvHigherRev,
+			new: rv,
+			err: ErrLowerRevNum,
+		},
+		// Case 3: update base with more work
+		{
+			old: rv,
+			new: rvMoreWork,
+			err: nil,
+		},
+		// Case 4: update more work rev with lower work base
+		{
+			old: rvMoreWork,
+			new: rv,
+			err: ErrSameRevNum,
+		},
+		// Case 5: update base with matching pubkey
+		{
+			old: rv,
+			new: rvPubKey,
+			err: nil,
+		},
+		// Case 6: update rv with pubkey with base
+		{
+			old: rvPubKey,
+			new: rv,
+			err: ErrSameWork,
+		},
+	}
+	for i, test := range tests {
+		err = test.old.CanUpdateWith(test.new, spk)
+		if test.err != err && !errors.Contains(err, test.err) {
+			t.Fatalf("%v: %v != %v", i, err, test.err)
+		}
+	}
+}
 
 // TestHashRegistryValue tests that signing registry values results in expected
 // values.
 func TestHashRegistryValue(t *testing.T) {
+	t.Parallel()
+
 	expected := "788dddf5232807611557a3dc0fa5f34012c2650526ba91d55411a2b04ba56164"
 	dataKey := "HelloWorld"
 	tweak := crypto.HashAll(dataKey)
@@ -27,27 +117,30 @@ func TestHashRegistryValue(t *testing.T) {
 
 // TestHasMoreWork is a unit test for the registry entry's HasMoreWork method.
 func TestHasMoreWork(t *testing.T) {
+	t.Parallel()
+
 	// Create the rv's from hardcoded values for which we know the resulting
 	// hash.
-	rv1Data, err := hex.DecodeString("9c0e0775d2176f1f9984")
+	rv1Data, err := hex.DecodeString("829675d476f4795e5e3caf6583d1f323a8f065236b9ace5296dfd6b24c876ba7f135")
 	if err != nil {
 		t.Fatal(err)
 	}
-	rv2Data, err := hex.DecodeString("d609d8de783665bfb437")
+	rv2Data, err := hex.DecodeString("0673b5a673596d840db8f714bbf6751e7d1869fca23e67fa20803597f925ac45e445")
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	rv1 := NewRegistryValue(crypto.Hash{}, rv1Data, 0)
 	rv2 := NewRegistryValue(crypto.Hash{}, rv2Data, 0)
 
 	// Make sure the hashes match our expectations.
-	rv1Hash := "659f49276a066a4b2434c9ffb953efee63d255e69c5541fb1785b54ebc10fbad"
-	rv2Hash := "0c46015835772a5aa99ca8999fa8b876bb2293cd16ca2fbff8c858a64813eb51"
+	rv1Hash := "c598bbad313e0003ce9a95b07b46fcb1abf09dd605389287b4aa9a583f38a901"
+	rv2Hash := "b4afc3c50a9a087d7a1cb82ca14dac1f456f30742856056ff5269eb3a1b7343c"
 	if rv1.hash().String() != rv1Hash {
 		t.Fatal("rv1 wrong hash")
 	}
 	if rv2.hash().String() != rv2Hash {
-		t.Fatal("rv1 wrong hash")
+		t.Fatal("rv2 wrong hash")
 	}
 
 	// rv2 should have more work than rv1
@@ -62,10 +155,22 @@ func TestHasMoreWork(t *testing.T) {
 	if rv1.HasMoreWork(rv1) {
 		t.Fatal("rv1 shouldn't have more work than itself")
 	}
+	// adding a pubkey to rv1 shouldn't change the work but the hash.
+	rv1WithPubkey := rv1
+	_, pk := crypto.GenerateKeyPair()
+	rv1WithPubkey.Data = append(rv1WithPubkey.Data, pk[:]...)
+	if rv1.work() != rv1WithPubkey.work() {
+		t.Fatal("work should match")
+	}
+	if rv1.hash() == rv1WithPubkey.hash() {
+		t.Fatal("hash should change")
+	}
 }
 
 // TestRegistryValueSignature tests signature verification on registry values.
 func TestRegistryValueSignature(t *testing.T) {
+	t.Parallel()
+
 	signedRV := func() (SignedRegistryValue, crypto.PublicKey) {
 		sk, pk := crypto.GenerateKeyPair()
 		rv := NewRegistryValue(crypto.Hash{1}, fastrand.Bytes(100), 2).Sign(sk)
@@ -96,7 +201,7 @@ func TestRegistryValueSignature(t *testing.T) {
 	}
 	// Verify invalid - wrong data
 	rv, pk = signedRV()
-	rv.Data = fastrand.Bytes(100)
+	rv.Data = fastrand.Bytes(RegistryEntryDataSize)
 	if err := rv.Verify(pk); err == nil {
 		t.Fatal("verification succeeded")
 	}
@@ -105,5 +210,39 @@ func TestRegistryValueSignature(t *testing.T) {
 	rv.Revision = fastrand.Uint64n(math.MaxUint64)
 	if err := rv.Verify(pk); err == nil {
 		t.Fatal("verification succeeded")
+	}
+}
+
+// TestParsePubKey is a unit test for ParsePubKey.
+func TestParsePubKey(t *testing.T) {
+	t.Parallel()
+
+	// value without pubkey.
+	rv := NewRegistryValue(crypto.Hash{}, fastrand.Bytes(RegistryEntryDataSize), 0)
+	spk, err := rv.ParsePubKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if spk != nil {
+		t.Fatal("spk should be nil")
+	}
+
+	// value with pubkey.
+	_, pk := crypto.GenerateKeyPair()
+	spk2 := types.Ed25519PublicKey(pk)
+	rv.Data = append(rv.Data, pk[:]...)
+	spk, err = rv.ParsePubKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !spk.Equals(spk2) {
+		t.Fatal("spk doesn't match spk2")
+	}
+
+	// invalid data length shouldn't panic.
+	rv = NewRegistryValue(crypto.Hash{}, []byte{}, 0)
+	_, err = rv.ParsePubKey()
+	if err == nil {
+		t.Fatal("expect error")
 	}
 }

--- a/modules/registry_test.go
+++ b/modules/registry_test.go
@@ -158,7 +158,8 @@ func TestHasMoreWork(t *testing.T) {
 	// adding a pubkey to rv1 shouldn't change the work but the hash.
 	rv1WithPubkey := rv1
 	_, pk := crypto.GenerateKeyPair()
-	rv1WithPubkey.Data = append(rv1WithPubkey.Data, pk[:]...)
+	spkh := crypto.HashObject(types.Ed25519PublicKey(pk))
+	rv1WithPubkey.Data = append(rv1WithPubkey.Data, spkh[:]...)
 	if rv1.work() != rv1WithPubkey.work() {
 		t.Fatal("work should match")
 	}
@@ -230,12 +231,13 @@ func TestParsePubKey(t *testing.T) {
 	// value with pubkey.
 	_, pk := crypto.GenerateKeyPair()
 	spk2 := types.Ed25519PublicKey(pk)
-	rv.Data = append(rv.Data, pk[:]...)
-	spk, err = rv.ParsePubKey()
+	spk2h := crypto.HashObject(spk2)
+	rv.Data = append(rv.Data, spk2h[:]...)
+	spkh, err := rv.ParsePubKey()
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !spk.Equals(spk2) {
+	if *spkh != spk2h {
 		t.Fatal("spk doesn't match spk2")
 	}
 

--- a/modules/registry_test.go
+++ b/modules/registry_test.go
@@ -125,11 +125,11 @@ func TestHasMoreWork(t *testing.T) {
 
 	// Create the rv's from hardcoded values for which we know the resulting
 	// hash.
-	rv1Data, err := hex.DecodeString("829675d476f4795e5e3caf6583d1f323a8f065236b9ace5296dfd6b24c876ba7f135")
+	rv1Data, err := hex.DecodeString("732e473d43831439cc0e9afe560a0e666868cfe66eac19ab53235fcb5e4e9222e72f499a8fc9bd9d8d2b66c9f6eba266e3017297b7b7a1898415f7ab44b4e48b64f5e594bd27400442ed608cb336d80463cfefcd089f62401f3e6ae4")
 	if err != nil {
 		t.Fatal(err)
 	}
-	rv2Data, err := hex.DecodeString("0673b5a673596d840db8f714bbf6751e7d1869fca23e67fa20803597f925ac45e445")
+	rv2Data, err := hex.DecodeString("a9acd0b5be0acd08e67ab53637d9b7ae0f82e354f9cf0aa615bc5c6a77a05f315b042131358aa18c1978a574f2b1ea80d5ad8f5d441aa490583f2f790c348b5c102ce6f161fa2df6cb713fbe11b57c9a9cbe274534077afba0184ae26fb9d59d2983aad92cd8c6949c548cb81491d060b4")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -138,8 +138,8 @@ func TestHasMoreWork(t *testing.T) {
 	rv2 := NewRegistryValue(crypto.Hash{}, rv2Data, 0)
 
 	// Make sure the hashes match our expectations.
-	rv1Hash := "c598bbad313e0003ce9a95b07b46fcb1abf09dd605389287b4aa9a583f38a901"
-	rv2Hash := "b4afc3c50a9a087d7a1cb82ca14dac1f456f30742856056ff5269eb3a1b7343c"
+	rv1Hash := "2d6dcb452e01d7146238ca65543be7fdd7ed0c1f17d340797a1980bea31f73c1"
+	rv2Hash := "28d9d973d0b4dee185f90649d55ac33d9e1301896b5b20578fb82c887921040b"
 	if rv1.hash().String() != rv1Hash {
 		t.Fatal("rv1 wrong hash")
 	}
@@ -160,11 +160,11 @@ func TestHasMoreWork(t *testing.T) {
 		t.Fatal("rv1 shouldn't have more work than itself")
 	}
 	// adding a pubkey to rv1 shouldn't change the work but the hash.
-	rv1WithPubkey := rv1
 	_, pk := crypto.GenerateKeyPair()
-	spkh := crypto.HashObject(types.Ed25519PublicKey(pk))
-	rv1WithPubkey.Data = append(rv1WithPubkey.Data, spkh[:]...)
+	rv1WithPubkey := NewRegistryValueWithPubKey(rv1.Tweak, types.Ed25519PublicKey(pk), rv1Data, rv1.Revision)
 	if rv1.work() != rv1WithPubkey.work() {
+		t.Log(rv1.Data)
+		t.Log(rv1WithPubkey.Data[HostPubKeyHashSize:])
 		t.Fatal("work should match")
 	}
 	if rv1.hash() == rv1WithPubkey.hash() {

--- a/modules/renter/registry.go
+++ b/modules/renter/registry.go
@@ -9,7 +9,6 @@ import (
 	"go.sia.tech/siad/build"
 	"go.sia.tech/siad/crypto"
 	"go.sia.tech/siad/modules"
-	"go.sia.tech/siad/modules/host/registry"
 	"go.sia.tech/siad/types"
 )
 
@@ -521,7 +520,7 @@ func (r *Renter) managedUpdateRegistry(ctx context.Context, spk types.SiaPublicK
 			// If we receive ErrLowerRevNum or ErrSameRevNum, remember the revision number
 			// that was presented as proof. In the end we return the highest one to be able
 			// to determine the next revision number that is save to use.
-			if (errors.Contains(resp.staticErr, registry.ErrLowerRevNum) || errors.Contains(resp.staticErr, registry.ErrSameRevNum)) &&
+			if (errors.Contains(resp.staticErr, modules.ErrLowerRevNum) || errors.Contains(resp.staticErr, modules.ErrSameRevNum)) &&
 				resp.srv.Revision > highestInvalidRevNum {
 				highestInvalidRevNum = resp.srv.Revision
 				invalidRevNum = true
@@ -538,9 +537,9 @@ func (r *Renter) managedUpdateRegistry(ctx context.Context, spk types.SiaPublicK
 	// to the highest invalid revision we remembered.
 	if invalidRevNum {
 		if highestInvalidRevNum == srv.Revision {
-			err = registry.ErrSameRevNum
+			err = modules.ErrSameRevNum
 		} else {
-			err = registry.ErrLowerRevNum
+			err = modules.ErrLowerRevNum
 		}
 	}
 

--- a/modules/renter/workeraccount_test.go
+++ b/modules/renter/workeraccount_test.go
@@ -564,7 +564,7 @@ func testWorkerAccountSpendingDetails(t *testing.T, wt *workerTester) {
 		Algorithm: types.SignatureEd25519,
 		Key:       pk[:],
 	}
-	rv := modules.NewRegistryValue(tweak, fastrand.Bytes(modules.RegistryDataSize), fastrand.Uint64n(1000)).Sign(sk)
+	rv := modules.NewRegistryValue(tweak, fastrand.Bytes(modules.RegistryEntryDataSize), fastrand.Uint64n(1000)).Sign(sk)
 
 	// update the registry
 	err := wt.UpdateRegistry(context.Background(), spk, rv)

--- a/modules/renter/workeraccount_test.go
+++ b/modules/renter/workeraccount_test.go
@@ -564,7 +564,7 @@ func testWorkerAccountSpendingDetails(t *testing.T, wt *workerTester) {
 		Algorithm: types.SignatureEd25519,
 		Key:       pk[:],
 	}
-	rv := modules.NewRegistryValue(tweak, fastrand.Bytes(modules.RegistryEntryDataSize), fastrand.Uint64n(1000)).Sign(sk)
+	rv := modules.NewRegistryValue(tweak, fastrand.Bytes(modules.RegistryDataSize), fastrand.Uint64n(1000)).Sign(sk)
 
 	// update the registry
 	err := wt.UpdateRegistry(context.Background(), spk, rv)

--- a/modules/renter/workeraccount_test.go
+++ b/modules/renter/workeraccount_test.go
@@ -564,7 +564,7 @@ func testWorkerAccountSpendingDetails(t *testing.T, wt *workerTester) {
 		Algorithm: types.SignatureEd25519,
 		Key:       pk[:],
 	}
-	rv := modules.NewRegistryValue(tweak, fastrand.Bytes(modules.RegistryDataSize), fastrand.Uint64n(1000)).Sign(sk)
+	rv := modules.NewRegistryValue(tweak, fastrand.Bytes(modules.RegistryDataSize-1), fastrand.Uint64n(1000)).Sign(sk)
 
 	// update the registry
 	err := wt.UpdateRegistry(context.Background(), spk, rv)

--- a/modules/renter/workerjobreadregistry_test.go
+++ b/modules/renter/workerjobreadregistry_test.go
@@ -35,7 +35,7 @@ func TestReadRegistryJob(t *testing.T) {
 	sk, pk := crypto.GenerateKeyPair()
 	var tweak crypto.Hash
 	fastrand.Read(tweak[:])
-	data := fastrand.Bytes(modules.RegistryDataSize)
+	data := fastrand.Bytes(modules.RegistryDataSize - 1)
 	rev := fastrand.Uint64n(1000)
 	spk := types.SiaPublicKey{
 		Algorithm: types.SignatureEd25519,
@@ -88,7 +88,7 @@ func TestReadRegistryInvalidCached(t *testing.T) {
 	sk, pk := crypto.GenerateKeyPair()
 	var tweak crypto.Hash
 	fastrand.Read(tweak[:])
-	data := fastrand.Bytes(modules.RegistryDataSize)
+	data := fastrand.Bytes(modules.RegistryDataSize - 1)
 	rev := fastrand.Uint64n(1000) + 1
 	spk := types.SiaPublicKey{
 		Algorithm: types.SignatureEd25519,
@@ -155,7 +155,7 @@ func TestReadRegistryCachedUpdated(t *testing.T) {
 	sk, pk := crypto.GenerateKeyPair()
 	var tweak crypto.Hash
 	fastrand.Read(tweak[:])
-	data := fastrand.Bytes(modules.RegistryDataSize)
+	data := fastrand.Bytes(modules.RegistryDataSize - 1)
 	rev := fastrand.Uint64n(1000) + 1
 	spk := types.SiaPublicKey{
 		Algorithm: types.SignatureEd25519,

--- a/modules/renter/workerjobreadregistry_test.go
+++ b/modules/renter/workerjobreadregistry_test.go
@@ -35,7 +35,7 @@ func TestReadRegistryJob(t *testing.T) {
 	sk, pk := crypto.GenerateKeyPair()
 	var tweak crypto.Hash
 	fastrand.Read(tweak[:])
-	data := fastrand.Bytes(modules.RegistryEntryDataSize)
+	data := fastrand.Bytes(modules.RegistryDataSize)
 	rev := fastrand.Uint64n(1000)
 	spk := types.SiaPublicKey{
 		Algorithm: types.SignatureEd25519,
@@ -88,7 +88,7 @@ func TestReadRegistryInvalidCached(t *testing.T) {
 	sk, pk := crypto.GenerateKeyPair()
 	var tweak crypto.Hash
 	fastrand.Read(tweak[:])
-	data := fastrand.Bytes(modules.RegistryEntryDataSize)
+	data := fastrand.Bytes(modules.RegistryDataSize)
 	rev := fastrand.Uint64n(1000) + 1
 	spk := types.SiaPublicKey{
 		Algorithm: types.SignatureEd25519,
@@ -155,7 +155,7 @@ func TestReadRegistryCachedUpdated(t *testing.T) {
 	sk, pk := crypto.GenerateKeyPair()
 	var tweak crypto.Hash
 	fastrand.Read(tweak[:])
-	data := fastrand.Bytes(modules.RegistryEntryDataSize)
+	data := fastrand.Bytes(modules.RegistryDataSize)
 	rev := fastrand.Uint64n(1000) + 1
 	spk := types.SiaPublicKey{
 		Algorithm: types.SignatureEd25519,

--- a/modules/renter/workerjobreadregistry_test.go
+++ b/modules/renter/workerjobreadregistry_test.go
@@ -35,7 +35,7 @@ func TestReadRegistryJob(t *testing.T) {
 	sk, pk := crypto.GenerateKeyPair()
 	var tweak crypto.Hash
 	fastrand.Read(tweak[:])
-	data := fastrand.Bytes(modules.RegistryDataSize)
+	data := fastrand.Bytes(modules.RegistryEntryDataSize)
 	rev := fastrand.Uint64n(1000)
 	spk := types.SiaPublicKey{
 		Algorithm: types.SignatureEd25519,
@@ -88,7 +88,7 @@ func TestReadRegistryInvalidCached(t *testing.T) {
 	sk, pk := crypto.GenerateKeyPair()
 	var tweak crypto.Hash
 	fastrand.Read(tweak[:])
-	data := fastrand.Bytes(modules.RegistryDataSize)
+	data := fastrand.Bytes(modules.RegistryEntryDataSize)
 	rev := fastrand.Uint64n(1000) + 1
 	spk := types.SiaPublicKey{
 		Algorithm: types.SignatureEd25519,
@@ -155,7 +155,7 @@ func TestReadRegistryCachedUpdated(t *testing.T) {
 	sk, pk := crypto.GenerateKeyPair()
 	var tweak crypto.Hash
 	fastrand.Read(tweak[:])
-	data := fastrand.Bytes(modules.RegistryDataSize)
+	data := fastrand.Bytes(modules.RegistryEntryDataSize)
 	rev := fastrand.Uint64n(1000) + 1
 	spk := types.SiaPublicKey{
 		Algorithm: types.SignatureEd25519,

--- a/modules/renter/workerjobupdateregistry.go
+++ b/modules/renter/workerjobupdateregistry.go
@@ -7,7 +7,6 @@ import (
 
 	"go.sia.tech/siad/build"
 	"go.sia.tech/siad/modules"
-	"go.sia.tech/siad/modules/host/registry"
 	"go.sia.tech/siad/types"
 
 	"gitlab.com/NebulousLabs/errors"
@@ -115,7 +114,7 @@ func (j *jobUpdateRegistry) callExecute() {
 	// in the future in case we are certain that a host can't contain those
 	// errors.
 	rv, err := j.managedUpdateRegistry()
-	if errors.Contains(err, registry.ErrLowerRevNum) || errors.Contains(err, registry.ErrSameRevNum) {
+	if errors.Contains(err, modules.ErrLowerRevNum) || errors.Contains(err, modules.ErrSameRevNum) {
 		// Report the failure if the host can't provide a signed registry entry
 		// with the error.
 		if err := rv.Verify(j.staticSiaPublicKey.ToPublicKey()); err != nil {
@@ -205,13 +204,13 @@ func (j *jobUpdateRegistry) managedUpdateRegistry() (modules.SignedRegistryValue
 		// signed registry value from the response.
 		err = resp.Error
 		// Check for ErrLowerRevNum.
-		if err != nil && strings.Contains(err.Error(), registry.ErrLowerRevNum.Error()) {
-			err = registry.ErrLowerRevNum
+		if err != nil && strings.Contains(err.Error(), modules.ErrLowerRevNum.Error()) {
+			err = modules.ErrLowerRevNum
 		}
-		if err != nil && strings.Contains(err.Error(), registry.ErrSameRevNum.Error()) {
-			err = registry.ErrSameRevNum
+		if err != nil && strings.Contains(err.Error(), modules.ErrSameRevNum.Error()) {
+			err = modules.ErrSameRevNum
 		}
-		if errors.Contains(err, registry.ErrLowerRevNum) || errors.Contains(err, registry.ErrSameRevNum) {
+		if errors.Contains(err, modules.ErrLowerRevNum) || errors.Contains(err, modules.ErrSameRevNum) {
 			// Parse the proof.
 			rv, parseErr := parseSignedRegistryValueResponse(resp.Output, j.staticSignedRegistryValue.Tweak)
 			return rv, errors.Compose(err, parseErr)

--- a/modules/renter/workerjobupdateregistry_test.go
+++ b/modules/renter/workerjobupdateregistry_test.go
@@ -10,7 +10,6 @@ import (
 	"gitlab.com/NebulousLabs/fastrand"
 	"go.sia.tech/siad/crypto"
 	"go.sia.tech/siad/modules"
-	"go.sia.tech/siad/modules/host/registry"
 	"go.sia.tech/siad/siatest/dependencies"
 	"go.sia.tech/siad/types"
 )
@@ -66,7 +65,7 @@ func TestUpdateRegistryJob(t *testing.T) {
 	// Run the UpdateRegistry job again. This time it should fail with an error
 	// indicating that the revision number already exists.
 	err = wt.UpdateRegistry(context.Background(), spk, rv)
-	if !errors.Contains(err, registry.ErrSameRevNum) {
+	if !errors.Contains(err, modules.ErrSameRevNum) {
 		t.Fatal(err)
 	}
 
@@ -108,7 +107,7 @@ func TestUpdateRegistryJob(t *testing.T) {
 	rvLowRevNum.Revision--
 	rvLowRevNum = rvLowRevNum.Sign(sk)
 	err = wt.UpdateRegistry(context.Background(), spk, rvLowRevNum)
-	if !errors.Contains(err, registry.ErrLowerRevNum) {
+	if !errors.Contains(err, modules.ErrLowerRevNum) {
 		t.Fatal(err)
 	}
 
@@ -129,7 +128,7 @@ func TestUpdateRegistryJob(t *testing.T) {
 	if !errors.Contains(err, crypto.ErrInvalidSignature) {
 		t.Fatal(err)
 	}
-	if errors.Contains(err, registry.ErrLowerRevNum) || errors.Contains(err, registry.ErrSameRevNum) {
+	if errors.Contains(err, modules.ErrLowerRevNum) || errors.Contains(err, modules.ErrSameRevNum) {
 		t.Fatal("Revision error should have been stripped", err)
 	}
 
@@ -139,7 +138,7 @@ func TestUpdateRegistryJob(t *testing.T) {
 	if !errors.Contains(wt.staticJobUpdateRegistryQueue.recentErr, crypto.ErrInvalidSignature) {
 		t.Fatal(err)
 	}
-	if errors.Contains(err, registry.ErrLowerRevNum) || errors.Contains(err, registry.ErrSameRevNum) {
+	if errors.Contains(err, modules.ErrLowerRevNum) || errors.Contains(err, modules.ErrSameRevNum) {
 		t.Fatal("Revision error should have been stripped", err)
 	}
 	if wt.staticJobUpdateRegistryQueue.cooldownUntil == (time.Time{}) {
@@ -239,10 +238,10 @@ func TestUpdateRegistryLyingHost(t *testing.T) {
 	if !errors.Contains(err, errHostOutdatedProof) {
 		t.Fatal("worker should return errHostOutdatedProof")
 	}
-	if errors.Contains(err, registry.ErrSameRevNum) {
+	if errors.Contains(err, modules.ErrSameRevNum) {
 		t.Fatal(err)
 	}
-	if errors.Contains(err, registry.ErrLowerRevNum) {
+	if errors.Contains(err, modules.ErrLowerRevNum) {
 		t.Fatal(err)
 	}
 }

--- a/modules/renter/workerjobupdateregistry_test.go
+++ b/modules/renter/workerjobupdateregistry_test.go
@@ -65,7 +65,7 @@ func TestUpdateRegistryJob(t *testing.T) {
 	// Run the UpdateRegistry job again. This time it should fail with an error
 	// indicating that the revision number already exists.
 	err = wt.UpdateRegistry(context.Background(), spk, rv)
-	if !errors.Contains(err, modules.ErrSameRevNum) {
+	if !errors.Contains(err, modules.ErrSameEntry) {
 		t.Fatal(err)
 	}
 

--- a/modules/renter/workerjobupdateregistry_test.go
+++ b/modules/renter/workerjobupdateregistry_test.go
@@ -37,7 +37,7 @@ func TestUpdateRegistryJob(t *testing.T) {
 	sk, pk := crypto.GenerateKeyPair()
 	var tweak crypto.Hash
 	fastrand.Read(tweak[:])
-	data := fastrand.Bytes(modules.RegistryDataSize)
+	data := fastrand.Bytes(modules.RegistryDataSize - 1)
 	rev := fastrand.Uint64n(1000) + 1
 	spk := types.SiaPublicKey{
 		Algorithm: types.SignatureEd25519,
@@ -201,7 +201,7 @@ func TestUpdateRegistryLyingHost(t *testing.T) {
 	sk, pk := crypto.GenerateKeyPair()
 	var tweak crypto.Hash
 	fastrand.Read(tweak[:])
-	data := fastrand.Bytes(modules.RegistryDataSize)
+	data := fastrand.Bytes(modules.RegistryDataSize - 1)
 	rev := fastrand.Uint64n(1000) + 1
 	spk := types.SiaPublicKey{
 		Algorithm: types.SignatureEd25519,
@@ -271,7 +271,7 @@ func TestUpdateRegistryInvalidCached(t *testing.T) {
 	sk, pk := crypto.GenerateKeyPair()
 	var tweak crypto.Hash
 	fastrand.Read(tweak[:])
-	data := fastrand.Bytes(modules.RegistryDataSize)
+	data := fastrand.Bytes(modules.RegistryDataSize - 1)
 	rev := fastrand.Uint64n(1000) + 1
 	spk := types.SiaPublicKey{
 		Algorithm: types.SignatureEd25519,

--- a/modules/renter/workerjobupdateregistry_test.go
+++ b/modules/renter/workerjobupdateregistry_test.go
@@ -37,7 +37,7 @@ func TestUpdateRegistryJob(t *testing.T) {
 	sk, pk := crypto.GenerateKeyPair()
 	var tweak crypto.Hash
 	fastrand.Read(tweak[:])
-	data := fastrand.Bytes(modules.RegistryEntryDataSize)
+	data := fastrand.Bytes(modules.RegistryDataSize)
 	rev := fastrand.Uint64n(1000) + 1
 	spk := types.SiaPublicKey{
 		Algorithm: types.SignatureEd25519,
@@ -201,7 +201,7 @@ func TestUpdateRegistryLyingHost(t *testing.T) {
 	sk, pk := crypto.GenerateKeyPair()
 	var tweak crypto.Hash
 	fastrand.Read(tweak[:])
-	data := fastrand.Bytes(modules.RegistryEntryDataSize)
+	data := fastrand.Bytes(modules.RegistryDataSize)
 	rev := fastrand.Uint64n(1000) + 1
 	spk := types.SiaPublicKey{
 		Algorithm: types.SignatureEd25519,
@@ -271,7 +271,7 @@ func TestUpdateRegistryInvalidCached(t *testing.T) {
 	sk, pk := crypto.GenerateKeyPair()
 	var tweak crypto.Hash
 	fastrand.Read(tweak[:])
-	data := fastrand.Bytes(modules.RegistryEntryDataSize)
+	data := fastrand.Bytes(modules.RegistryDataSize)
 	rev := fastrand.Uint64n(1000) + 1
 	spk := types.SiaPublicKey{
 		Algorithm: types.SignatureEd25519,

--- a/modules/renter/workerjobupdateregistry_test.go
+++ b/modules/renter/workerjobupdateregistry_test.go
@@ -37,7 +37,7 @@ func TestUpdateRegistryJob(t *testing.T) {
 	sk, pk := crypto.GenerateKeyPair()
 	var tweak crypto.Hash
 	fastrand.Read(tweak[:])
-	data := fastrand.Bytes(modules.RegistryDataSize)
+	data := fastrand.Bytes(modules.RegistryEntryDataSize)
 	rev := fastrand.Uint64n(1000) + 1
 	spk := types.SiaPublicKey{
 		Algorithm: types.SignatureEd25519,
@@ -201,7 +201,7 @@ func TestUpdateRegistryLyingHost(t *testing.T) {
 	sk, pk := crypto.GenerateKeyPair()
 	var tweak crypto.Hash
 	fastrand.Read(tweak[:])
-	data := fastrand.Bytes(modules.RegistryDataSize)
+	data := fastrand.Bytes(modules.RegistryEntryDataSize)
 	rev := fastrand.Uint64n(1000) + 1
 	spk := types.SiaPublicKey{
 		Algorithm: types.SignatureEd25519,
@@ -271,7 +271,7 @@ func TestUpdateRegistryInvalidCached(t *testing.T) {
 	sk, pk := crypto.GenerateKeyPair()
 	var tweak crypto.Hash
 	fastrand.Read(tweak[:])
-	data := fastrand.Bytes(modules.RegistryDataSize)
+	data := fastrand.Bytes(modules.RegistryEntryDataSize)
 	rev := fastrand.Uint64n(1000) + 1
 	spk := types.SiaPublicKey{
 		Algorithm: types.SignatureEd25519,

--- a/modules/renter/workersubscription_test.go
+++ b/modules/renter/workersubscription_test.go
@@ -44,7 +44,7 @@ func randomRegistryValue() (modules.SignedRegistryValue, types.SiaPublicKey, cry
 	sk, pk := crypto.GenerateKeyPair()
 	var tweak crypto.Hash
 	fastrand.Read(tweak[:])
-	data := fastrand.Bytes(modules.RegistryEntryDataSize)
+	data := fastrand.Bytes(modules.RegistryDataSize)
 	rev := fastrand.Uint64n(1000)
 	spk := types.SiaPublicKey{
 		Algorithm: types.SignatureEd25519,

--- a/modules/renter/workersubscription_test.go
+++ b/modules/renter/workersubscription_test.go
@@ -44,7 +44,7 @@ func randomRegistryValue() (modules.SignedRegistryValue, types.SiaPublicKey, cry
 	sk, pk := crypto.GenerateKeyPair()
 	var tweak crypto.Hash
 	fastrand.Read(tweak[:])
-	data := fastrand.Bytes(modules.RegistryDataSize)
+	data := fastrand.Bytes(modules.RegistryEntryDataSize)
 	rev := fastrand.Uint64n(1000)
 	spk := types.SiaPublicKey{
 		Algorithm: types.SignatureEd25519,

--- a/modules/renter/workersubscription_test.go
+++ b/modules/renter/workersubscription_test.go
@@ -45,6 +45,7 @@ func randomRegistryValue() (modules.SignedRegistryValue, types.SiaPublicKey, cry
 	var tweak crypto.Hash
 	fastrand.Read(tweak[:])
 	data := fastrand.Bytes(modules.RegistryDataSize)
+	data[len(data)-1] = modules.RegistryEntryVersionNoPubKey
 	rev := fastrand.Uint64n(1000)
 	spk := types.SiaPublicKey{
 		Algorithm: types.SignatureEd25519,


### PR DESCRIPTION
This MR changes the host's registry to be able to recognize a new type of registry entry.
The new type contains the first 20 bytes of the hash of a host at the beginning of the entry and the last byte of it is a version byte. 

For compatibility, any entry that is not a full 113 byte large, will be considered version 1 and won't be assumed to have a pubkey. An entry that is 113 large will have its last byte interpreted as a version.

Version 0: this is invalid
Version 1: entry doesn't contain a pubkey hash
Version 2: first 20 bytes are the hash of the pubkey

The intention is that a renter can update hosts with customized registry entries. If a user looks up a registry entry from a host, there are two options.

1. the registry entry contains a pubkey that matches the host's
2. the entry doesn't contain a pubkey at all or it contains one that doesn't match the host's

In case 1. we consider the host a primary host and in case 2 a secondary one. This implicitly tells the user who downloaded an entry whether the creator actively updates the host or not. 

Since only the creator can sign registry entries, nobody else can turn a host into a primary host by simply downloading a signed registry entry and reuploading it to a different host.
