### PR TITLE
Improve Registry Update

### DIFF
--- a/modules/host/contractmanager/sectorupdate_test.go
+++ b/modules/host/contractmanager/sectorupdate_test.go
@@ -2069,6 +2069,9 @@ func TestAddVirtualSectorOverflow(t *testing.T) {
 	if loadedOverflow != 1 {
 		t.Fatal("wrong overflow", loadedOverflow)
 	}
+	if err := loaded.Close(); err != nil {
+		t.Fatal(err)
+	}
 
 	// Remove the sector.
 	err = cmt.cm.RemoveSector(root)
@@ -2100,6 +2103,9 @@ func TestAddVirtualSectorOverflow(t *testing.T) {
 	loadedOverflow, exists = loaded.Overflow(id)
 	if !exists || loadedOverflow != 0 {
 		t.Fatal("overflow entry should be 0", loadedOverflow)
+	}
+	if err := loaded.Close(); err != nil {
+		t.Fatal(err)
 	}
 
 	// Create multiple threads, all adding sectors at the same time.
@@ -2144,6 +2150,9 @@ func TestAddVirtualSectorOverflow(t *testing.T) {
 	if loadedOverflow != uint64(nWrites*nThreads) {
 		t.Fatal("wrong overflow", loadedOverflow)
 	}
+	if err := loaded.Close(); err != nil {
+		t.Fatal(err)
+	}
 
 	// Create multiple threads, all of them removing sectors.
 	for i := 0; i < nThreads; i++ {
@@ -2185,5 +2194,8 @@ func TestAddVirtualSectorOverflow(t *testing.T) {
 	loadedOverflow, exists = loaded.Overflow(id)
 	if !exists || loadedOverflow != 0 {
 		t.Fatal("overflow entry should be 0", loadedOverflow)
+	}
+	if err := loaded.Close(); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/modules/host/contractmanager/sectorupdate_test.go
+++ b/modules/host/contractmanager/sectorupdate_test.go
@@ -2193,7 +2193,7 @@ func TestAddVirtualSectorOverflow(t *testing.T) {
 	}
 	loadedOverflow, exists = loaded.Overflow(id)
 	if !exists || loadedOverflow != 0 {
-		t.Fatal("overflow entry should be 0", loadedOverflow)
+		t.Fatal("overflow entry should be 0", exists, loadedOverflow)
 	}
 	if err := loaded.Close(); err != nil {
 		t.Fatal(err)

--- a/modules/host/contractmanager/sectorupdate_test.go
+++ b/modules/host/contractmanager/sectorupdate_test.go
@@ -1962,7 +1962,7 @@ func TestAddVirtualSectorOverflow(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	cmt, err := newContractManagerTester("TestAddVirtualSectorMassiveParallel")
+	cmt, err := newContractManagerTester("TestAddVirtualSectorOverflow")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2185,6 +2185,9 @@ func TestAddVirtualSectorOverflow(t *testing.T) {
 	if !exists || loadedOverflow != 0 {
 		t.Fatal("overflow entry should be 0", loadedOverflow)
 	}
+
+	// Sync the map to disk before reading it again.
+	cmt.cm.wal.syncResources()
 
 	// Load the overflow file and confirm that the change was persisted.
 	loaded, err = newOverflowMap(overflowFilePath, modules.ProdDependencies)

--- a/modules/host/contractmanager/sectorupdate_test.go
+++ b/modules/host/contractmanager/sectorupdate_test.go
@@ -1962,7 +1962,7 @@ func TestAddVirtualSectorOverflow(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	cmt, err := newContractManagerTester("TestAddVirtualSectorOverflow")
+	cmt, err := newContractManagerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/host/host.go
+++ b/modules/host/host.go
@@ -791,7 +791,7 @@ func (h *Host) RegistryUpdate(rv modules.SignedRegistryValue, pubKey types.SiaPu
 	if h.dependencies.Disrupt("RegistryUpdateLyingHost") {
 		_, srv, found := h.staticRegistry.Get(modules.DeriveRegistryEntryID(pubKey, rv.Tweak))
 		if found {
-			return srv, registry.ErrSameRevNum
+			return srv, modules.ErrSameRevNum
 		}
 	}
 	// On disrupt, the registry shouldn't be updated.

--- a/modules/host/mdm/instructionupdateregistry.go
+++ b/modules/host/mdm/instructionupdateregistry.go
@@ -4,7 +4,6 @@ import (
 	"encoding/binary"
 	"fmt"
 
-	"gitlab.com/NebulousLabs/errors"
 	"go.sia.tech/siad/modules"
 	"go.sia.tech/siad/types"
 )
@@ -95,9 +94,9 @@ func (i *instructionUpdateRegistry) Execute(prevOutput output) (output, types.Cu
 	// Try updating the registry.
 	rv := modules.NewSignedRegistryValue(tweak, data, revision, signature)
 	existingRV, err := i.staticState.host.RegistryUpdate(rv, pubKey, newExpiry)
-	if errors.Contains(err, modules.ErrLowerRevNum) || errors.Contains(err, modules.ErrSameRevNum) {
-		// If we weren't able to update the registry due to a ErrLowerRevNum or
-		// ErrSameRevNum, we need to return the existing value as proof.
+	if modules.IsRegistryEntryExistErr(err) {
+		// If we weren't able to update the registry because the entry already
+		// exists, we need to return a proof.
 		rev := make([]byte, 8)
 		binary.LittleEndian.PutUint64(rev, existingRV.Revision)
 		return output{

--- a/modules/host/mdm/instructionupdateregistry.go
+++ b/modules/host/mdm/instructionupdateregistry.go
@@ -6,7 +6,6 @@ import (
 
 	"gitlab.com/NebulousLabs/errors"
 	"go.sia.tech/siad/modules"
-	"go.sia.tech/siad/modules/host/registry"
 	"go.sia.tech/siad/types"
 )
 
@@ -96,7 +95,7 @@ func (i *instructionUpdateRegistry) Execute(prevOutput output) (output, types.Cu
 	// Try updating the registry.
 	rv := modules.NewSignedRegistryValue(tweak, data, revision, signature)
 	existingRV, err := i.staticState.host.RegistryUpdate(rv, pubKey, newExpiry)
-	if errors.Contains(err, registry.ErrLowerRevNum) || errors.Contains(err, registry.ErrSameRevNum) {
+	if errors.Contains(err, modules.ErrLowerRevNum) || errors.Contains(err, modules.ErrSameRevNum) {
 		// If we weren't able to update the registry due to a ErrLowerRevNum or
 		// ErrSameRevNum, we need to return the existing value as proof.
 		rev := make([]byte, 8)

--- a/modules/host/mdm/instructionupdateregistry_test.go
+++ b/modules/host/mdm/instructionupdateregistry_test.go
@@ -8,7 +8,6 @@ import (
 	"gitlab.com/NebulousLabs/fastrand"
 	"go.sia.tech/siad/crypto"
 	"go.sia.tech/siad/modules"
-	"go.sia.tech/siad/modules/host/registry"
 	"go.sia.tech/siad/types"
 )
 
@@ -68,7 +67,7 @@ func TestInstructionUpdateRegistry(t *testing.T) {
 	expectedOutput := append(rv.Signature[:], append(revBytes, rv.Data...)...)
 	// Assert output.
 	output = outputs[0]
-	err = output.assert(0, crypto.Hash{}, []crypto.Hash{}, expectedOutput, registry.ErrSameRevNum)
+	err = output.assert(0, crypto.Hash{}, []crypto.Hash{}, expectedOutput, modules.ErrSameRevNum)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -116,7 +115,7 @@ func TestInstructionUpdateRegistry(t *testing.T) {
 	expectedOutput = append(rv2.Signature[:], append(revBytes, rv2.Data...)...)
 	// Assert output.
 	output = outputs[0]
-	err = output.assert(0, crypto.Hash{}, []crypto.Hash{}, expectedOutput, registry.ErrLowerRevNum)
+	err = output.assert(0, crypto.Hash{}, []crypto.Hash{}, expectedOutput, modules.ErrLowerRevNum)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/host/mdm/mdm_test.go
+++ b/modules/host/mdm/mdm_test.go
@@ -13,7 +13,6 @@ import (
 	"gitlab.com/NebulousLabs/fastrand"
 	"go.sia.tech/siad/crypto"
 	"go.sia.tech/siad/modules"
-	"go.sia.tech/siad/modules/host/registry"
 	"go.sia.tech/siad/types"
 )
 
@@ -102,10 +101,10 @@ func (h *TestHost) RegistryUpdate(rv modules.SignedRegistryValue, pubKey types.S
 	oldRV, exists := h.registry[key]
 
 	if exists && rv.Revision < oldRV.Revision {
-		return oldRV.SignedRegistryValue, registry.ErrLowerRevNum
+		return oldRV.SignedRegistryValue, modules.ErrLowerRevNum
 	}
 	if exists && rv.Revision == oldRV.Revision {
-		return oldRV.SignedRegistryValue, registry.ErrSameRevNum
+		return oldRV.SignedRegistryValue, modules.ErrSameRevNum
 	}
 
 	h.registry[key] = TestRegistryValue{

--- a/modules/host/registry/registry.go
+++ b/modules/host/registry/registry.go
@@ -96,10 +96,10 @@ func (v *value) update(rv modules.SignedRegistryValue, newExpiry types.BlockHeig
 	// Check if the new revision number is valid.
 	oldRV := modules.NewRegistryValue(v.tweak, v.data, v.revision)
 	if !init {
-		s := fmt.Sprintf("%v <= %v", rv.Revision, v.revision)
+		s := fmt.Sprintf("%v <= %v", oldRV.Revision, rv.Revision)
 		update, err := oldRV.ShouldUpdateWith(&rv.RegistryValue)
 		if err != nil {
-			return errors.AddContext(modules.ErrLowerRevNum, s)
+			return errors.AddContext(err, s)
 		}
 		if !update {
 			return nil

--- a/modules/host/registry/registry.go
+++ b/modules/host/registry/registry.go
@@ -28,12 +28,6 @@ var (
 	// errEntryWrongSize is returned when a marshaled entry doesn't have a size
 	// of persistedEntrySize. This should never happen.
 	errEntryWrongSize = errors.New("marshaled entry has wrong size")
-	// ErrLowerRevNum is returned when the revision number of the data to
-	// register isn't greater than the known revision number.
-	ErrLowerRevNum = errors.New("provided revision number is invalid")
-	// ErrSameRevNum is returned if the revision number of the data to register
-	// is already registered.
-	ErrSameRevNum = errors.New("provided revision number is already registered")
 	// errInvalidSignature is returned when the signature doesn't match a
 	// registry value.
 	errInvalidSignature = errors.New("provided signature is invalid")
@@ -103,10 +97,12 @@ func (v *value) update(rv modules.SignedRegistryValue, newExpiry types.BlockHeig
 	oldRV := modules.NewRegistryValue(v.tweak, v.data, v.revision)
 	if !init {
 		s := fmt.Sprintf("%v <= %v", rv.Revision, v.revision)
-		if rv.Revision < oldRV.Revision {
-			return errors.AddContext(ErrLowerRevNum, s)
-		} else if rv.Revision == oldRV.Revision && !rv.HasMoreWork(oldRV) {
-			return errors.AddContext(ErrSameRevNum, s)
+		update, err := oldRV.ShouldUpdateWith(&rv.RegistryValue)
+		if err != nil {
+			return errors.AddContext(modules.ErrLowerRevNum, s)
+		}
+		if !update {
+			return nil
 		}
 	}
 

--- a/modules/host/registry/registry_test.go
+++ b/modules/host/registry/registry_test.go
@@ -242,7 +242,7 @@ func TestUpdate(t *testing.T) {
 	// same and the PoW is the same.
 	expectedRV := rv
 	oldRV, err = r.Update(rv, v.key, v.expiry)
-	if !errors.Contains(err, ErrSameRevNum) {
+	if !errors.Contains(err, modules.ErrSameRevNum) {
 		t.Fatal("expected invalid rev number", err)
 	}
 	if !reflect.DeepEqual(oldRV, expectedRV) {
@@ -276,7 +276,7 @@ func TestUpdate(t *testing.T) {
 	v.revision--
 	rv = rv.Sign(sk)
 	oldRV, err = r.Update(rv, v.key, v.expiry)
-	if !errors.Contains(err, ErrLowerRevNum) {
+	if !errors.Contains(err, modules.ErrLowerRevNum) {
 		t.Fatal("expected invalid rev number", err)
 	}
 	if !reflect.DeepEqual(oldRV, expectedRV) {
@@ -813,10 +813,10 @@ func TestRegistryRace(t *testing.T) {
 			exp := types.BlockHeight(atomic.AddUint64(nextExpiry, 1))
 			rv = rv.Sign(sk)
 			_, err := r.Update(rv, key, exp)
-			if errors.Contains(err, ErrSameRevNum) {
+			if errors.Contains(err, modules.ErrSameRevNum) {
 				continue // invalid revision numbers are expected
 			}
-			if errors.Contains(err, ErrLowerRevNum) {
+			if errors.Contains(err, modules.ErrLowerRevNum) {
 				continue // invalid revision numbers are expected
 			}
 			if errors.Contains(err, errInvalidEntry) {

--- a/modules/host/rpcexecuteprogram_test.go
+++ b/modules/host/rpcexecuteprogram_test.go
@@ -18,7 +18,6 @@ import (
 	"go.sia.tech/siad/build"
 	"go.sia.tech/siad/crypto"
 	"go.sia.tech/siad/modules"
-	"go.sia.tech/siad/modules/host/registry"
 	"go.sia.tech/siad/siatest/dependencies"
 	"go.sia.tech/siad/types"
 )
@@ -1352,7 +1351,7 @@ func TestExecuteUpdateRegistryProgram(t *testing.T) {
 	resp = resps[0]
 
 	// Check response.
-	if resp.Error == nil || !strings.Contains(resp.Error.Error(), registry.ErrSameRevNum.Error()) {
+	if resp.Error == nil || !strings.Contains(resp.Error.Error(), modules.ErrSameRevNum.Error()) {
 		t.Fatal(resp.Error)
 	}
 	if !resp.AdditionalCollateral.Equals(collateral) {
@@ -1424,7 +1423,7 @@ func TestExecuteUpdateRegistryProgram(t *testing.T) {
 	resp = resps[0]
 
 	// Check response.
-	if resp.Error == nil || !strings.Contains(resp.Error.Error(), registry.ErrLowerRevNum.Error()) {
+	if resp.Error == nil || !strings.Contains(resp.Error.Error(), modules.ErrLowerRevNum.Error()) {
 		t.Fatal(resp.Error)
 	}
 	if !resp.AdditionalCollateral.Equals(collateral) {

--- a/modules/host/rpcsubscribe.go
+++ b/modules/host/rpcsubscribe.go
@@ -147,14 +147,14 @@ func (h *Host) managedHandleSubscribeRequest(info *subscriptionInfo, pt *modules
 		return errors.AddContext(modules.ErrInsufficientPaymentForRPC, "managedHandleSubscribeRequest")
 	}
 
+	// Add the subscriptions.
+	h.staticRegistrySubscriptions.AddSubscriptions(info, ids...)
+
 	// Write initial values to the stream.
 	err = modules.RPCWrite(stream, rvs)
 	if err != nil {
 		return errors.AddContext(err, "failed to write initial values to stream")
 	}
-
-	// Add the subscriptions.
-	h.staticRegistrySubscriptions.AddSubscriptions(info, ids...)
 	return nil
 }
 

--- a/modules/registry.go
+++ b/modules/registry.go
@@ -3,6 +3,7 @@ package modules
 import (
 	"bytes"
 
+	"gitlab.com/NebulousLabs/errors"
 	"go.sia.tech/siad/crypto"
 )
 
@@ -24,6 +25,19 @@ const (
 
 	// FileIDVersion is the current version we expect in a FileID.
 	FileIDVersion = 1
+)
+
+var (
+	// ErrInsufficientWork is returned when the revision numbers of two entries
+	// match but the new entry doesn't have enough pow to replace the existing
+	// one.
+	ErrInsufficientWork = errors.New("entry doesn't have enough pow to replace existing entry")
+	// ErrLowerRevNum is returned when the revision number of the data to
+	// register isn't greater than the known revision number.
+	ErrLowerRevNum = errors.New("provided revision number is invalid")
+	// ErrSameRevNum is returned if the revision number of the data to register
+	// is already registered.
+	ErrSameRevNum = errors.New("provided revision number is already registered")
 )
 
 // RoundRegistrySize is a helper to correctly round up the size of a registry to
@@ -77,6 +91,41 @@ func (entry RegistryValue) Sign(sk crypto.SecretKey) SignedRegistryValue {
 		RegistryValue: entry,
 		Signature:     crypto.SignHash(hash, sk),
 	}
+}
+
+// ShouldUpdateWith returns true if entry2 would replace entry1 in a host's
+// registry. It returns false if it shouldn't. An error might be returned in
+// that case to specify the reason.
+func (entry *RegistryValue) ShouldUpdateWith(entry2 *RegistryValue) (bool, error) {
+	// Check entries for nil first.
+	if entry == nil && entry2 != nil {
+		return true, nil
+	} else if entry != nil && entry2 == nil {
+		return false, nil
+	}
+	// Both are not nil. Check revision numbers.
+	if entry.Revision > entry2.Revision {
+		return false, ErrLowerRevNum
+	} else if entry.Revision < entry2.Revision {
+		return true, nil
+	}
+	// Both have the same revision number. Check work.
+	if entry.HasMoreWork(*entry2) {
+		return false, ErrInsufficientWork
+	} else if entry2.HasMoreWork(*entry) {
+		return true, nil
+	}
+	// Both have the same work. Entries appear to be equal.
+	return false, ErrSameRevNum
+}
+
+// IsRegistryEntryExistErr returns true if the provided error is related to the
+// host already storing a higher priority registry entry.
+func IsRegistryEntryExistErr(err error) bool {
+	if errors.Contains(err, ErrLowerRevNum) || errors.Contains(err, ErrInsufficientWork) || errors.Contains(err, ErrSameRevNum) {
+		return true
+	}
+	return false
 }
 
 // HasMoreWork returns 'true' if the hash of entry is larger than target's.

--- a/modules/registry.go
+++ b/modules/registry.go
@@ -98,10 +98,12 @@ func (entry RegistryValue) Sign(sk crypto.SecretKey) SignedRegistryValue {
 // that case to specify the reason.
 func (entry *RegistryValue) ShouldUpdateWith(entry2 *RegistryValue) (bool, error) {
 	// Check entries for nil first.
-	if entry == nil && entry2 != nil {
-		return true, nil
-	} else if entry != nil && entry2 == nil {
+	if entry2 == nil {
+		// A nil entry never replaces an existing entry.
 		return false, nil
+	} else if entry == nil {
+		// A non-nil entry always replaces a nil entry.
+		return true, nil
 	}
 	// Both are not nil. Check revision numbers.
 	if entry.Revision > entry2.Revision {
@@ -122,10 +124,7 @@ func (entry *RegistryValue) ShouldUpdateWith(entry2 *RegistryValue) (bool, error
 // IsRegistryEntryExistErr returns true if the provided error is related to the
 // host already storing a higher priority registry entry.
 func IsRegistryEntryExistErr(err error) bool {
-	if errors.Contains(err, ErrLowerRevNum) || errors.Contains(err, ErrInsufficientWork) || errors.Contains(err, ErrSameRevNum) {
-		return true
-	}
-	return false
+	return errors.Contains(err, ErrLowerRevNum) || errors.Contains(err, ErrInsufficientWork) || errors.Contains(err, ErrSameRevNum)
 }
 
 // HasMoreWork returns 'true' if the hash of entry is larger than target's.

--- a/modules/registry_test.go
+++ b/modules/registry_test.go
@@ -108,6 +108,7 @@ func TestRegistryValueSignature(t *testing.T) {
 	}
 }
 
+// TestShouldUpdateWith is a unit test for ShouldUpdateWith.
 func TestShouldUpdateWith(t *testing.T) {
 	tests := []struct {
 		existing *RegistryValue
@@ -123,6 +124,12 @@ func TestShouldUpdateWith(t *testing.T) {
 		},
 		{
 			existing: &RegistryValue{},
+			new:      nil,
+			result:   false,
+			err:      nil,
+		},
+		{
+			existing: nil,
 			new:      nil,
 			result:   false,
 			err:      nil,

--- a/modules/registry_test.go
+++ b/modules/registry_test.go
@@ -107,3 +107,62 @@ func TestRegistryValueSignature(t *testing.T) {
 		t.Fatal("verification succeeded")
 	}
 }
+
+func TestShouldUpdateWith(t *testing.T) {
+	tests := []struct {
+		existing *RegistryValue
+		new      *RegistryValue
+		result   bool
+		err      error
+	}{
+		{
+			existing: nil,
+			new:      &RegistryValue{},
+			result:   true,
+			err:      nil,
+		},
+		{
+			existing: &RegistryValue{},
+			new:      nil,
+			result:   false,
+			err:      nil,
+		},
+		{
+			existing: &RegistryValue{Revision: 0},
+			new:      &RegistryValue{Revision: 1},
+			result:   true,
+			err:      nil,
+		},
+		{
+			existing: &RegistryValue{Revision: 1},
+			new:      &RegistryValue{Revision: 0},
+			result:   false,
+			err:      ErrLowerRevNum,
+		},
+		{
+			existing: &RegistryValue{Revision: 0, Tweak: crypto.Hash{1, 2, 3}},
+			new:      &RegistryValue{Revision: 0, Tweak: crypto.Hash{3, 2, 1}},
+			result:   true,
+			err:      nil,
+		},
+		{
+			existing: &RegistryValue{Revision: 0, Tweak: crypto.Hash{3, 2, 1}},
+			new:      &RegistryValue{Revision: 0, Tweak: crypto.Hash{1, 2, 3}},
+			result:   false,
+			err:      ErrInsufficientWork,
+		},
+		{
+			existing: &RegistryValue{Revision: 1},
+			new:      &RegistryValue{Revision: 1},
+			result:   false,
+			err:      ErrSameRevNum,
+		},
+	}
+
+	for i, test := range tests {
+		result, err := test.existing.ShouldUpdateWith(test.new)
+		if result != test.result || err != test.err {
+			t.Errorf("%v: wrong result/error expected %v and %v but was %v and %v", i, test.result, test.err, result, err)
+		}
+	}
+}

--- a/modules/renter/hostdb/hostdb_test.go
+++ b/modules/renter/hostdb/hostdb_test.go
@@ -54,7 +54,7 @@ func bareHostDB() *HostDB {
 	}
 	hdb.weightFunc = hdb.managedCalculateHostWeightFn(hdb.allowance)
 	hdb.staticHostTree = hosttree.New(hdb.weightFunc, &modules.ProductionResolver{})
-	hdb.staticFilteredTree = hosttree.New(hdb.weightFunc, &modules.ProductionResolver{})
+	hdb.filteredTree = hosttree.New(hdb.weightFunc, &modules.ProductionResolver{})
 	return hdb
 }
 
@@ -232,7 +232,7 @@ func TestRandomHosts(t *testing.T) {
 	for i := 0; i < nEntries; i++ {
 		entry := makeHostDBEntry()
 		entries[entry.PublicKey.String()] = entry
-		err := hdbt.hdb.staticFilteredTree.Insert(entry)
+		err := hdbt.hdb.filteredTree.Insert(entry)
 		if err != nil {
 			t.Error(err)
 		}

--- a/modules/renter/hostdb/persist.go
+++ b/modules/renter/hostdb/persist.go
@@ -70,7 +70,7 @@ func (hdb *HostDB) load() error {
 	hdb.filterMode = data.FilterMode
 
 	if len(hdb.filteredHosts) > 0 {
-		hdb.staticFilteredTree = hosttree.New(hdb.weightFunc, modules.ProdDependencies.Resolver())
+		hdb.filteredTree = hosttree.New(hdb.weightFunc, modules.ProdDependencies.Resolver())
 	}
 
 	// Load each of the hosts into the host trees.

--- a/modules/renter/hostdb/randomhosts.go
+++ b/modules/renter/hostdb/randomhosts.go
@@ -16,14 +16,15 @@ func (hdb *HostDB) RandomHosts(n int, blacklist, addressBlacklist []types.SiaPub
 	hdb.mu.RLock()
 	initialScanComplete := hdb.initialScanComplete
 	ipCheckDisabled := hdb.disableIPViolationCheck
+	filteredTree := hdb.filteredTree
 	hdb.mu.RUnlock()
 	if !initialScanComplete {
 		return []modules.HostDBEntry{}, ErrInitialScanIncomplete
 	}
 	if ipCheckDisabled {
-		return hdb.staticFilteredTree.SelectRandom(n, blacklist, nil), nil
+		return filteredTree.SelectRandom(n, blacklist, nil), nil
 	}
-	return hdb.staticFilteredTree.SelectRandom(n, blacklist, addressBlacklist), nil
+	return filteredTree.SelectRandom(n, blacklist, addressBlacklist), nil
 }
 
 // RandomHostsWithAllowance works as RandomHosts but uses a temporary hosttree

--- a/modules/renter/registry.go
+++ b/modules/renter/registry.go
@@ -9,7 +9,6 @@ import (
 	"go.sia.tech/siad/build"
 	"go.sia.tech/siad/crypto"
 	"go.sia.tech/siad/modules"
-	"go.sia.tech/siad/modules/host/registry"
 	"go.sia.tech/siad/types"
 )
 
@@ -521,7 +520,7 @@ func (r *Renter) managedUpdateRegistry(ctx context.Context, spk types.SiaPublicK
 			// If we receive ErrLowerRevNum or ErrSameRevNum, remember the revision number
 			// that was presented as proof. In the end we return the highest one to be able
 			// to determine the next revision number that is save to use.
-			if (errors.Contains(resp.staticErr, registry.ErrLowerRevNum) || errors.Contains(resp.staticErr, registry.ErrSameRevNum)) &&
+			if (errors.Contains(resp.staticErr, modules.ErrLowerRevNum) || errors.Contains(resp.staticErr, modules.ErrSameRevNum)) &&
 				resp.srv.Revision > highestInvalidRevNum {
 				highestInvalidRevNum = resp.srv.Revision
 				invalidRevNum = true
@@ -538,9 +537,9 @@ func (r *Renter) managedUpdateRegistry(ctx context.Context, spk types.SiaPublicK
 	// to the highest invalid revision we remembered.
 	if invalidRevNum {
 		if highestInvalidRevNum == srv.Revision {
-			err = registry.ErrSameRevNum
+			err = modules.ErrSameRevNum
 		} else {
-			err = registry.ErrLowerRevNum
+			err = modules.ErrLowerRevNum
 		}
 	}
 

--- a/modules/renter/workerjobupdateregistry.go
+++ b/modules/renter/workerjobupdateregistry.go
@@ -214,6 +214,9 @@ func (j *jobUpdateRegistry) managedUpdateRegistry() (modules.SignedRegistryValue
 		if err != nil && strings.Contains(err.Error(), modules.ErrSameRevNum.Error()) {
 			err = modules.ErrSameRevNum
 		}
+		if err != nil && strings.Contains(err.Error(), modules.ErrInsufficientWork.Error()) {
+			err = modules.ErrInsufficientWork
+		}
 		if modules.IsRegistryEntryExistErr(err) {
 			// Parse the proof.
 			rv, parseErr := parseSignedRegistryValueResponse(resp.Output, j.staticSignedRegistryValue.Tweak)

--- a/modules/renter/workerjobupdateregistry_test.go
+++ b/modules/renter/workerjobupdateregistry_test.go
@@ -10,7 +10,6 @@ import (
 	"gitlab.com/NebulousLabs/fastrand"
 	"go.sia.tech/siad/crypto"
 	"go.sia.tech/siad/modules"
-	"go.sia.tech/siad/modules/host/registry"
 	"go.sia.tech/siad/siatest/dependencies"
 	"go.sia.tech/siad/types"
 )
@@ -66,7 +65,7 @@ func TestUpdateRegistryJob(t *testing.T) {
 	// Run the UpdateRegistry job again. This time it should fail with an error
 	// indicating that the revision number already exists.
 	err = wt.UpdateRegistry(context.Background(), spk, rv)
-	if !errors.Contains(err, registry.ErrSameRevNum) {
+	if !errors.Contains(err, modules.ErrSameRevNum) {
 		t.Fatal(err)
 	}
 
@@ -108,7 +107,7 @@ func TestUpdateRegistryJob(t *testing.T) {
 	rvLowRevNum.Revision--
 	rvLowRevNum = rvLowRevNum.Sign(sk)
 	err = wt.UpdateRegistry(context.Background(), spk, rvLowRevNum)
-	if !errors.Contains(err, registry.ErrLowerRevNum) {
+	if !errors.Contains(err, modules.ErrLowerRevNum) {
 		t.Fatal(err)
 	}
 
@@ -129,7 +128,7 @@ func TestUpdateRegistryJob(t *testing.T) {
 	if !errors.Contains(err, crypto.ErrInvalidSignature) {
 		t.Fatal(err)
 	}
-	if errors.Contains(err, registry.ErrLowerRevNum) || errors.Contains(err, registry.ErrSameRevNum) {
+	if errors.Contains(err, modules.ErrLowerRevNum) || errors.Contains(err, modules.ErrSameRevNum) {
 		t.Fatal("Revision error should have been stripped", err)
 	}
 
@@ -139,7 +138,7 @@ func TestUpdateRegistryJob(t *testing.T) {
 	if !errors.Contains(wt.staticJobUpdateRegistryQueue.recentErr, crypto.ErrInvalidSignature) {
 		t.Fatal(err)
 	}
-	if errors.Contains(err, registry.ErrLowerRevNum) || errors.Contains(err, registry.ErrSameRevNum) {
+	if errors.Contains(err, modules.ErrLowerRevNum) || errors.Contains(err, modules.ErrSameRevNum) {
 		t.Fatal("Revision error should have been stripped", err)
 	}
 	if wt.staticJobUpdateRegistryQueue.cooldownUntil == (time.Time{}) {
@@ -239,10 +238,10 @@ func TestUpdateRegistryLyingHost(t *testing.T) {
 	if !errors.Contains(err, errHostOutdatedProof) {
 		t.Fatal("worker should return errHostOutdatedProof")
 	}
-	if errors.Contains(err, registry.ErrSameRevNum) {
+	if errors.Contains(err, modules.ErrSameRevNum) {
 		t.Fatal(err)
 	}
-	if errors.Contains(err, registry.ErrLowerRevNum) {
+	if errors.Contains(err, modules.ErrLowerRevNum) {
 		t.Fatal(err)
 	}
 }

--- a/modules/renter/workersubscription_test.go
+++ b/modules/renter/workersubscription_test.go
@@ -1011,7 +1011,7 @@ func TestHandleNotification(t *testing.T) {
 			subInfo.mu.Unlock()
 			// Stream should have been closed.
 			if closer.staticCount() != 1 {
-				return errors.New("stream should have been closed")
+				return fmt.Errorf("stream should have been closed: %v", closer.staticCount())
 			}
 			return nil
 		})
@@ -1048,7 +1048,7 @@ func TestHandleNotification(t *testing.T) {
 			subInfo.mu.Unlock()
 			// Stream should have been closed.
 			if closer.staticCount() != 2 {
-				return errors.New("stream should have been closed")
+				return fmt.Errorf("stream should have been closed: %v", closer.staticCount())
 			}
 			return nil
 		})
@@ -1080,7 +1080,7 @@ func TestHandleNotification(t *testing.T) {
 			subInfo.mu.Unlock()
 			// Stream should have been closed.
 			if closer.staticCount() != 3 {
-				return errors.New("stream should have been closed")
+				return fmt.Errorf("stream should have been closed: %v", closer.staticCount())
 			}
 			return nil
 		})
@@ -1136,7 +1136,7 @@ func TestHandleNotification(t *testing.T) {
 		}
 		err = build.Retry(100, 100*time.Millisecond, func() error {
 			if closer.staticCount() != 4 {
-				return errors.New("stream should have been closed")
+				return fmt.Errorf("stream should have been closed: %v", closer.staticCount())
 			}
 			return nil
 		})

--- a/siatest/renter/renter_test.go
+++ b/siatest/renter/renter_test.go
@@ -4761,7 +4761,7 @@ func TestWorkerStatus(t *testing.T) {
 		pks[c.HostPublicKey.String()] = struct{}{}
 	}
 
-	err = build.Retry(100, 100*time.Millisecond, func() error {
+	err = build.Retry(100, 1000*time.Millisecond, func() error {
 		// Get the worker status
 		rwg, err := r.RenterWorkersGet()
 		if err != nil {


### PR DESCRIPTION
This MR contains various improvements to the registry update instruction.

1. It pulls a few pieces of code out into helper functions
2. Custom error for when an entry can't be updated due to insufficient work
3. ErrSameRevNum is only returned when the entries have the same revision and pow. This means they are considered equal. The worker won't consider the update a failure in that case.
4. fixes data race in hdb to get tests to pass