### PR TITLE
Update UpdateRegistry instruction with entryType byte

### DIFF
--- a/modules/mdm.go
+++ b/modules/mdm.go
@@ -123,6 +123,13 @@ const (
 	// pubKeyLength + dataOffset + dataLength = 7 * 8 bytes = 56 byte
 	RPCIUpdateRegistryLen = 56
 
+	// RPCIUpdateRegistryWithVersionLen is the expected length of the 'Args' of
+	// an UpdateRegistry instruction with a version byte at the end.
+	// tweakOffset + revisionOffset + signatureOffset + pubKeyOffset +
+	// pubKeyLength + dataOffset + dataLength + version = 7 * 8 + 1 bytes = 57
+	// byte
+	RPCIUpdateRegistryWithVersionLen = 57
+
 	// RPCIReadRegistryLen is the expected length of the 'Args' of an
 	// ReadRegistry instruction.
 	// tweakOffset + pubKeyOffset + pubKeyLength = 3 * 8 bytes = 24 byte

--- a/modules/registry_test.go
+++ b/modules/registry_test.go
@@ -142,6 +142,18 @@ func TestRegistryValueSignature(t *testing.T) {
 		if err := rv.Verify(pk); err == nil {
 			t.Fatal("verification succeeded")
 		}
+		// Verify invalid - wrong type.
+		rv, pk = signedRV(entryType)
+		if rv.Type == RegistryEntryType(RegistryTypeWithPubkey) {
+			rv.Type = RegistryEntryType(RegistryTypeWithoutPubkey)
+		} else if rv.Type == RegistryEntryType(RegistryTypeWithoutPubkey) {
+			rv.Type = RegistryEntryType(RegistryTypeWithPubkey)
+		} else {
+			t.Fatal("unknown type")
+		}
+		if err := rv.Verify(pk); err == nil {
+			t.Fatal("verification succeeded")
+		}
 	}
 	test(RegistryTypeWithPubkey)
 	test(RegistryTypeWithoutPubkey)


### PR DESCRIPTION
This MR upgrades the UpdateRegistry MDM instruction to contain an entryByte byte.

That way, the renter can tell the host how to interpret the received entry. Right now the options are either as an entry with pubkey or without a pubkey.