### PR TITLE
Update ReadRegistry instruction with version byte

### DIFF
--- a/modules/host/mdm/builder_test.go
+++ b/modules/host/mdm/builder_test.go
@@ -120,10 +120,31 @@ func (tb *testProgramBuilder) AddUpdateRegistryInstruction(spk types.SiaPublicKe
 	tb.staticValues.AddUpdateRegistryInstruction(spk, rv)
 }
 
+// AddUpdateRegistryInstructionV156 adds an UpdateRegistry instruction to the
+// builder, keeping track of running values.
+func (tb *testProgramBuilder) AddUpdateRegistryInstructionV156(spk types.SiaPublicKey, rv modules.SignedRegistryValue) {
+	err := tb.staticPB.V156AddUpdateRegistryInstruction(spk, rv)
+	if err != nil {
+		panic(err)
+	}
+	tb.staticValues.AddUpdateRegistryInstruction(spk, rv)
+}
+
 // AddReadRegistryInstruction adds an ReadRegistry instruction to the
 // builder, keeping track of running values.
-func (tb *testProgramBuilder) AddReadRegistryInstruction(spk types.SiaPublicKey, tweak crypto.Hash, refunded bool) types.Currency {
-	refund, err := tb.staticPB.AddReadRegistryInstruction(spk, tweak)
+func (tb *testProgramBuilder) AddReadRegistryInstruction(spk types.SiaPublicKey, tweak crypto.Hash, refunded bool, version modules.ReadRegistryVersion) types.Currency {
+	refund, err := tb.staticPB.AddReadRegistryInstruction(spk, tweak, version)
+	if err != nil {
+		panic(err)
+	}
+	tb.staticValues.AddReadRegistryInstruction(spk, refunded)
+	return refund
+}
+
+// AddReadRegistryInstructionV156 adds an ReadRegistry instruction to the
+// builder, keeping track of running values.
+func (tb *testProgramBuilder) AddReadRegistryInstructionV156(spk types.SiaPublicKey, tweak crypto.Hash, refunded bool) types.Currency {
+	refund, err := tb.staticPB.V156AddReadRegistryInstruction(spk, tweak)
 	if err != nil {
 		panic(err)
 	}
@@ -133,8 +154,19 @@ func (tb *testProgramBuilder) AddReadRegistryInstruction(spk types.SiaPublicKey,
 
 // AddReadRegistryInstruction adds an ReadRegistry instruction to the
 // builder, keeping track of running values.
-func (tb *testProgramBuilder) AddReadRegistryEIDInstruction(sid modules.RegistryEntryID, refunded, needPubKeyAndTweak bool) types.Currency {
-	refund, err := tb.staticPB.AddReadRegistryEIDInstruction(sid, needPubKeyAndTweak)
+func (tb *testProgramBuilder) AddReadRegistryEIDInstruction(sid modules.RegistryEntryID, refunded, needPubKeyAndTweak bool, version modules.ReadRegistryVersion) types.Currency {
+	refund, err := tb.staticPB.AddReadRegistryEIDInstruction(sid, needPubKeyAndTweak, version)
+	if err != nil {
+		panic(err)
+	}
+	tb.staticValues.AddReadRegistryEIDInstruction(sid, refunded)
+	return refund
+}
+
+// AddReadRegistryInstruction adds an ReadRegistry instruction to the
+// builder, keeping track of running values.
+func (tb *testProgramBuilder) AddReadRegistryEIDInstructionV156(sid modules.RegistryEntryID, refunded, needPubKeyAndTweak bool) types.Currency {
+	refund, err := tb.staticPB.V156AddReadRegistryEIDInstruction(sid, needPubKeyAndTweak)
 	if err != nil {
 		panic(err)
 	}

--- a/modules/host/mdm/instructionreadregistry_test.go
+++ b/modules/host/mdm/instructionreadregistry_test.go
@@ -49,6 +49,12 @@ func testInstructionReadRegistry(t *testing.T, addReadRegistryInstruction func(t
 		Key:       pk[:],
 	}
 	rv := modules.NewRegistryValue(tweak, data, rev, modules.RegistryTypeWithoutPubkey).Sign(sk)
+	if fastrand.Intn(2) == 0 {
+		rv.Type = modules.RegistryTypeWithPubkey
+		spkh := crypto.HashObject(spk)
+		rv.Data = append(spkh[:modules.RegistryPubKeyHashSize], rv.Data...)
+		rv = rv.Sign(sk)
+	}
 	_, err := host.RegistryUpdate(rv, spk, types.BlockHeight(fastrand.Uint64n(1000)))
 	if err != nil {
 		t.Fatal(err)

--- a/modules/host/mdm/instructionreadregistry_test.go
+++ b/modules/host/mdm/instructionreadregistry_test.go
@@ -12,6 +12,25 @@ import (
 
 // TestInstructionReadRegistry tests the ReadRegistry instruction.
 func TestInstructionReadRegistry(t *testing.T) {
+	t.Run("NoTypeV156", func(t *testing.T) {
+		testInstructionReadRegistry(t, func(tb *testProgramBuilder, spk types.SiaPublicKey, tweak crypto.Hash) {
+			tb.AddReadRegistryInstructionV156(spk, tweak, false)
+		})
+	})
+	t.Run("NoType", func(t *testing.T) {
+		testInstructionReadRegistry(t, func(tb *testProgramBuilder, spk types.SiaPublicKey, tweak crypto.Hash) {
+			tb.AddReadRegistryInstruction(spk, tweak, false, modules.ReadRegistryVersionNoType)
+		})
+	})
+	t.Run("WithType", func(t *testing.T) {
+		testInstructionReadRegistry(t, func(tb *testProgramBuilder, spk types.SiaPublicKey, tweak crypto.Hash) {
+			tb.AddReadRegistryInstruction(spk, tweak, false, modules.ReadRegistryVersionWithType)
+		})
+	})
+}
+
+// testInstructionReadRegistry tests the ReadRegistry instruction.
+func testInstructionReadRegistry(t *testing.T, addReadRegistryInstruction func(tb *testProgramBuilder, spk types.SiaPublicKey, tweak crypto.Hash)) {
 	host := newTestHost()
 	mdm := New(host)
 	defer mdm.Stop()
@@ -35,7 +54,7 @@ func TestInstructionReadRegistry(t *testing.T) {
 	so := host.newTestStorageObligation(true)
 	pt := newTestPriceTable()
 	tb := newTestProgramBuilder(pt, 0)
-	tb.AddReadRegistryInstruction(spk, tweak, false)
+	addReadRegistryInstruction(tb, spk, tweak)
 
 	// Execute it.
 	outputs, err := mdm.ExecuteProgramWithBuilder(tb, so, 0, false)
@@ -81,7 +100,7 @@ func TestInstructionReadRegistryNotFound(t *testing.T) {
 	so := host.newTestStorageObligation(true)
 	pt := newTestPriceTable()
 	tb := newTestProgramBuilder(pt, 0)
-	refund := tb.AddReadRegistryInstruction(spk, crypto.Hash{}, true)
+	refund := tb.AddReadRegistryInstruction(spk, crypto.Hash{}, true, modules.ReadRegistryVersionWithType)
 
 	// Execute it.
 	outputs, remainingBudget, err := mdm.ExecuteProgramWithBuilderCustomBudget(tb, so, 0, false)

--- a/modules/host/mdm/instructionreadregistry_test.go
+++ b/modules/host/mdm/instructionreadregistry_test.go
@@ -51,8 +51,6 @@ func testInstructionReadRegistry(t *testing.T, addReadRegistryInstruction func(t
 	rv := modules.NewRegistryValue(tweak, data, rev, modules.RegistryTypeWithoutPubkey).Sign(sk)
 	if fastrand.Intn(2) == 0 {
 		rv.Type = modules.RegistryTypeWithPubkey
-		spkh := crypto.HashObject(spk)
-		rv.Data = append(spkh[:modules.RegistryPubKeyHashSize], rv.Data...)
 		rv = rv.Sign(sk)
 	}
 	_, err := host.RegistryUpdate(rv, spk, types.BlockHeight(fastrand.Uint64n(1000)))

--- a/modules/host/mdm/instructionreadregistrysid.go
+++ b/modules/host/mdm/instructionreadregistrysid.go
@@ -38,7 +38,7 @@ func (p *program) staticDecodeReadRegistryEIDInstruction(instruction modules.Ins
 	needPubKeyAndTweak := instruction.Args[8] == 1
 	iType := modules.ReadRegistryVersionNoType
 	if len(instruction.Args) == modules.RPCIReadRegistryEIDWithVersionLen {
-		iType = modules.ReadRegistryVersion(instruction.Args[8])
+		iType = modules.ReadRegistryVersion(instruction.Args[9])
 	}
 	return &instructionReadRegistryEID{
 		commonInstruction: commonInstruction{

--- a/modules/host/mdm/instructionreadregistrysid_test.go
+++ b/modules/host/mdm/instructionreadregistrysid_test.go
@@ -15,24 +15,27 @@ import (
 // TestInstructionReadRegistryEID tests the ReadRegistryEID instruction.
 func TestInstructionReadRegistryEID(t *testing.T) {
 	t.Run("NoTypeV156", func(t *testing.T) {
-		testInstructionReadRegistryEID(t, func(tb *testProgramBuilder, rid modules.RegistryEntryID) {
+		testInstructionReadRegistryEID(t, func(tb *testProgramBuilder, rid modules.RegistryEntryID) modules.ReadRegistryVersion {
 			tb.AddReadRegistryEIDInstructionV156(rid, false, true)
+			return modules.ReadRegistryVersionNoType
 		})
 	})
 	t.Run("NoType", func(t *testing.T) {
-		testInstructionReadRegistryEID(t, func(tb *testProgramBuilder, rid modules.RegistryEntryID) {
+		testInstructionReadRegistryEID(t, func(tb *testProgramBuilder, rid modules.RegistryEntryID) modules.ReadRegistryVersion {
 			tb.AddReadRegistryEIDInstruction(rid, false, true, modules.ReadRegistryVersionNoType)
+			return modules.ReadRegistryVersionNoType
 		})
 	})
 	t.Run("WithType", func(t *testing.T) {
-		testInstructionReadRegistryEID(t, func(tb *testProgramBuilder, rid modules.RegistryEntryID) {
+		testInstructionReadRegistryEID(t, func(tb *testProgramBuilder, rid modules.RegistryEntryID) modules.ReadRegistryVersion {
 			tb.AddReadRegistryEIDInstruction(rid, false, true, modules.ReadRegistryVersionWithType)
+			return modules.ReadRegistryVersionWithType
 		})
 	})
 }
 
 // TestInstructionReadRegistryEID tests the ReadRegistryEID instruction.
-func testInstructionReadRegistryEID(t *testing.T, addReadRegistryEIDInstruction func(tb *testProgramBuilder, rid modules.RegistryEntryID)) {
+func testInstructionReadRegistryEID(t *testing.T, addReadRegistryEIDInstruction func(tb *testProgramBuilder, rid modules.RegistryEntryID) modules.ReadRegistryVersion) {
 	host := newTestHost()
 	mdm := New(host)
 	defer mdm.Stop()
@@ -56,7 +59,7 @@ func testInstructionReadRegistryEID(t *testing.T, addReadRegistryEIDInstruction 
 	so := host.newTestStorageObligation(true)
 	pt := newTestPriceTable()
 	tb := newTestProgramBuilder(pt, 0)
-	addReadRegistryEIDInstruction(tb, modules.DeriveRegistryEntryID(spk, tweak))
+	version := addReadRegistryEIDInstruction(tb, modules.DeriveRegistryEntryID(spk, tweak))
 
 	// Execute it.
 	outputs, err := mdm.ExecuteProgramWithBuilder(tb, so, 0, false)
@@ -72,6 +75,9 @@ func testInstructionReadRegistryEID(t *testing.T, addReadRegistryEIDInstruction 
 	expectedOutput = append(expectedOutput, rv.Signature[:]...)
 	expectedOutput = append(expectedOutput, revBytes...)
 	expectedOutput = append(expectedOutput, rv.Data...)
+	if version == modules.ReadRegistryVersionWithType {
+		expectedOutput = append(expectedOutput, byte(rv.Type))
+	}
 	err = output.assert(0, crypto.Hash{}, []crypto.Hash{}, expectedOutput, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -93,6 +99,13 @@ func testInstructionReadRegistryEID(t *testing.T, addReadRegistryEIDInstruction 
 		t.Fatal(err)
 	}
 	data2 = data2[:n]
+	if version == modules.ReadRegistryVersionWithType {
+		// The last byte might be the entry type.
+		if data2[len(data2)-1] != byte(rv.Type) {
+			t.Fatal("wrong type")
+		}
+		data2 = data2[:len(data2)-1]
+	}
 	rv2 := modules.NewSignedRegistryValue(tweak2, data2, rev2, sig2, modules.RegistryTypeWithoutPubkey)
 	if err := rv2.Verify(spk2.ToPublicKey()); err != nil {
 		t.Fatal("verification failed", err)
@@ -160,7 +173,7 @@ func TestInstructionReadRegistryEIDNoPubkeyAndTweak(t *testing.T) {
 	so := host.newTestStorageObligation(true)
 	pt := newTestPriceTable()
 	tb := newTestProgramBuilder(pt, 0)
-	tb.AddReadRegistryEIDInstruction(modules.DeriveRegistryEntryID(spk, tweak), false, false, modules.ReadRegistryVersionWithType)
+	tb.AddReadRegistryEIDInstruction(modules.DeriveRegistryEntryID(spk, tweak), false, false, modules.ReadRegistryVersionNoType)
 
 	// Execute it.
 	outputs, err := mdm.ExecuteProgramWithBuilder(tb, so, 0, false)

--- a/modules/host/mdm/instructionreadregistrysid_test.go
+++ b/modules/host/mdm/instructionreadregistrysid_test.go
@@ -53,8 +53,6 @@ func testInstructionReadRegistryEID(t *testing.T, addReadRegistryEIDInstruction 
 	rv := modules.NewRegistryValue(tweak, data, rev, modules.RegistryTypeWithoutPubkey).Sign(sk)
 	if fastrand.Intn(2) == 0 {
 		rv.Type = modules.RegistryTypeWithPubkey
-		spkh := crypto.HashObject(spk)
-		rv.Data = append(spkh[:modules.RegistryPubKeyHashSize], rv.Data...)
 		rv = rv.Sign(sk)
 	}
 	_, err := host.RegistryUpdate(rv, spk, types.BlockHeight(fastrand.Uint64n(1000)))

--- a/modules/host/mdm/instructionreadregistrysid_test.go
+++ b/modules/host/mdm/instructionreadregistrysid_test.go
@@ -51,6 +51,12 @@ func testInstructionReadRegistryEID(t *testing.T, addReadRegistryEIDInstruction 
 		Key:       pk[:],
 	}
 	rv := modules.NewRegistryValue(tweak, data, rev, modules.RegistryTypeWithoutPubkey).Sign(sk)
+	if fastrand.Intn(2) == 0 {
+		rv.Type = modules.RegistryTypeWithPubkey
+		spkh := crypto.HashObject(spk)
+		rv.Data = append(spkh[:modules.RegistryPubKeyHashSize], rv.Data...)
+		rv = rv.Sign(sk)
+	}
 	_, err := host.RegistryUpdate(rv, spk, types.BlockHeight(fastrand.Uint64n(1000)))
 	if err != nil {
 		t.Fatal(err)
@@ -106,7 +112,7 @@ func testInstructionReadRegistryEID(t *testing.T, addReadRegistryEIDInstruction 
 		}
 		data2 = data2[:len(data2)-1]
 	}
-	rv2 := modules.NewSignedRegistryValue(tweak2, data2, rev2, sig2, modules.RegistryTypeWithoutPubkey)
+	rv2 := modules.NewSignedRegistryValue(tweak2, data2, rev2, sig2, rv.Type)
 	if err := rv2.Verify(spk2.ToPublicKey()); err != nil {
 		t.Fatal("verification failed", err)
 	}
@@ -204,7 +210,7 @@ func TestInstructionReadRegistryEIDNoPubkeyAndTweak(t *testing.T) {
 		t.Fatal(err)
 	}
 	data2 = data2[:n]
-	rv2 := modules.NewSignedRegistryValue(tweak, data2, rev2, sig2, modules.RegistryTypeWithoutPubkey)
+	rv2 := modules.NewSignedRegistryValue(tweak, data2, rev2, sig2, rv.Type)
 	if err := rv2.Verify(pk); err != nil {
 		t.Fatal("verification failed", err)
 	}

--- a/modules/host/mdm/instructionreadregistrysid_test.go
+++ b/modules/host/mdm/instructionreadregistrysid_test.go
@@ -14,6 +14,25 @@ import (
 
 // TestInstructionReadRegistryEID tests the ReadRegistryEID instruction.
 func TestInstructionReadRegistryEID(t *testing.T) {
+	t.Run("NoTypeV156", func(t *testing.T) {
+		testInstructionReadRegistryEID(t, func(tb *testProgramBuilder, rid modules.RegistryEntryID) {
+			tb.AddReadRegistryEIDInstructionV156(rid, false, true)
+		})
+	})
+	t.Run("NoType", func(t *testing.T) {
+		testInstructionReadRegistryEID(t, func(tb *testProgramBuilder, rid modules.RegistryEntryID) {
+			tb.AddReadRegistryEIDInstruction(rid, false, true, modules.ReadRegistryVersionNoType)
+		})
+	})
+	t.Run("WithType", func(t *testing.T) {
+		testInstructionReadRegistryEID(t, func(tb *testProgramBuilder, rid modules.RegistryEntryID) {
+			tb.AddReadRegistryEIDInstruction(rid, false, true, modules.ReadRegistryVersionWithType)
+		})
+	})
+}
+
+// TestInstructionReadRegistryEID tests the ReadRegistryEID instruction.
+func testInstructionReadRegistryEID(t *testing.T, addReadRegistryEIDInstruction func(tb *testProgramBuilder, rid modules.RegistryEntryID)) {
 	host := newTestHost()
 	mdm := New(host)
 	defer mdm.Stop()
@@ -37,7 +56,7 @@ func TestInstructionReadRegistryEID(t *testing.T) {
 	so := host.newTestStorageObligation(true)
 	pt := newTestPriceTable()
 	tb := newTestProgramBuilder(pt, 0)
-	tb.AddReadRegistryEIDInstruction(modules.DeriveRegistryEntryID(spk, tweak), false, true)
+	addReadRegistryEIDInstruction(tb, modules.DeriveRegistryEntryID(spk, tweak))
 
 	// Execute it.
 	outputs, err := mdm.ExecuteProgramWithBuilder(tb, so, 0, false)
@@ -97,7 +116,7 @@ func TestInstructionReadRegistryEIDNotFound(t *testing.T) {
 	so := host.newTestStorageObligation(true)
 	pt := newTestPriceTable()
 	tb := newTestProgramBuilder(pt, 0)
-	refund := tb.AddReadRegistryEIDInstruction(modules.DeriveRegistryEntryID(spk, crypto.Hash{}), true, true)
+	refund := tb.AddReadRegistryEIDInstruction(modules.DeriveRegistryEntryID(spk, crypto.Hash{}), true, true, modules.ReadRegistryVersionWithType)
 
 	// Execute it.
 	outputs, remainingBudget, err := mdm.ExecuteProgramWithBuilderCustomBudget(tb, so, 0, false)
@@ -141,7 +160,7 @@ func TestInstructionReadRegistryEIDNoPubkeyAndTweak(t *testing.T) {
 	so := host.newTestStorageObligation(true)
 	pt := newTestPriceTable()
 	tb := newTestProgramBuilder(pt, 0)
-	tb.AddReadRegistryEIDInstruction(modules.DeriveRegistryEntryID(spk, tweak), false, false)
+	tb.AddReadRegistryEIDInstruction(modules.DeriveRegistryEntryID(spk, tweak), false, false, modules.ReadRegistryVersionWithType)
 
 	// Execute it.
 	outputs, err := mdm.ExecuteProgramWithBuilder(tb, so, 0, false)

--- a/modules/host/mdm/instructionupdateregistry_test.go
+++ b/modules/host/mdm/instructionupdateregistry_test.go
@@ -15,19 +15,34 @@ import (
 // TestInstructionUpdateRegistry tests the update registry instruction with
 // different types of entries.
 func TestInstructionUpdateRegistry(t *testing.T) {
+	t.Run("NoPubkeyV156", func(t *testing.T) {
+		entryType := modules.RegistryTypeWithoutPubkey
+		testInstructionUpdateRegistry(t, entryType, func(tb *testProgramBuilder, spk types.SiaPublicKey, rv modules.SignedRegistryValue) {
+			tb.AddUpdateRegistryInstructionV156(spk, rv)
+		})
+	})
 	t.Run("NoPubkey", func(t *testing.T) {
-		testInstructionUpdateRegistry(t, modules.RegistryTypeWithoutPubkey)
+		entryType := modules.RegistryTypeWithoutPubkey
+		testInstructionUpdateRegistry(t, entryType, func(tb *testProgramBuilder, spk types.SiaPublicKey, rv modules.SignedRegistryValue) {
+			tb.AddUpdateRegistryInstruction(spk, rv)
+		})
 	})
 	t.Run("WithPubkey", func(t *testing.T) {
-		testInstructionUpdateRegistry(t, modules.RegistryTypeWithPubkey)
+		entryType := modules.RegistryTypeWithPubkey
+		testInstructionUpdateRegistry(t, entryType, func(tb *testProgramBuilder, spk types.SiaPublicKey, rv modules.SignedRegistryValue) {
+			tb.AddUpdateRegistryInstruction(spk, rv)
+		})
 	})
 	t.Run("Invalid", func(t *testing.T) {
-		testInstructionUpdateRegistry(t, modules.RegistryTypeInvalid)
+		entryType := modules.RegistryTypeInvalid
+		testInstructionUpdateRegistry(t, entryType, func(tb *testProgramBuilder, spk types.SiaPublicKey, rv modules.SignedRegistryValue) {
+			tb.AddUpdateRegistryInstruction(spk, rv)
+		})
 	})
 }
 
 // testInstructionUpdateRegistry tests the update registry instruction.
-func testInstructionUpdateRegistry(t *testing.T, entryType modules.RegistryEntryType) {
+func testInstructionUpdateRegistry(t *testing.T, entryType modules.RegistryEntryType, addUpdateRegistryInstruction func(tb *testProgramBuilder, spk types.SiaPublicKey, rv modules.SignedRegistryValue)) {
 	host := newTestHost()
 	mdm := New(host)
 	defer mdm.Stop()
@@ -45,7 +60,7 @@ func testInstructionUpdateRegistry(t *testing.T, entryType modules.RegistryEntry
 
 	pt := newTestPriceTable()
 	tb := newTestProgramBuilder(pt, 0)
-	tb.AddUpdateRegistryInstruction(spk, rv)
+	addUpdateRegistryInstruction(tb, spk, rv)
 
 	// Execute it.
 	so := host.newTestStorageObligation(true)
@@ -98,7 +113,7 @@ func testInstructionUpdateRegistry(t *testing.T, entryType modules.RegistryEntry
 	tb = newTestProgramBuilder(pt, 0)
 	rv.Revision++
 	rv = rv.Sign(sk)
-	tb.AddUpdateRegistryInstruction(spk, rv)
+	addUpdateRegistryInstruction(tb, spk, rv)
 	outputs, err = mdm.ExecuteProgramWithBuilder(tb, so, 0, false)
 	if err != nil {
 		t.Fatal(err)
@@ -127,7 +142,7 @@ func testInstructionUpdateRegistry(t *testing.T, entryType modules.RegistryEntry
 	oldRevision := rv.Revision
 	rv.Revision = 0
 	rv = rv.Sign(sk)
-	tb.AddUpdateRegistryInstruction(spk, rv)
+	addUpdateRegistryInstruction(tb, spk, rv)
 	outputs, err = mdm.ExecuteProgramWithBuilder(tb, so, 0, false)
 	if err != nil {
 		t.Fatal(err)
@@ -148,7 +163,7 @@ func testInstructionUpdateRegistry(t *testing.T, entryType modules.RegistryEntry
 	rv.Revision = oldRevision + 1
 	rv.Data = []byte{}
 	rv = rv.Sign(sk)
-	tb.AddUpdateRegistryInstruction(spk, rv)
+	addUpdateRegistryInstruction(tb, spk, rv)
 
 	// Execute it.
 	outputs, err = mdm.ExecuteProgramWithBuilder(tb, so, 0, false)

--- a/modules/host/rpcexecuteprogram_test.go
+++ b/modules/host/rpcexecuteprogram_test.go
@@ -1518,7 +1518,7 @@ func TestExecuteReadRegistryProgram(t *testing.T) {
 	// Create the 'UpdateRegistry' program.
 	pt := rhp.managedPriceTable()
 	pb := modules.NewProgramBuilder(pt, types.BlockHeight(fastrand.Uint64n(1000))) // random duration since ReadRegistry doesn't depend on duration.
-	_, err = pb.AddReadRegistryInstruction(spk, rv.Tweak)
+	_, err = pb.AddReadRegistryInstruction(spk, rv.Tweak, modules.ReadRegistryVersionWithType)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/mdm.go
+++ b/modules/mdm.go
@@ -28,6 +28,22 @@ type (
 	// MDMCancellationToken is a token that can be used to request cancellation
 	// of a program
 	MDMCancellationToken [MDMCancellationTokenLen]byte
+
+	// ReadRegistryVersion specifies the version of a read registry instruction.
+	ReadRegistryVersion uint8
+)
+
+const (
+	// ReadRegistryVersionInvalid is an uninitialized read registry version.
+	ReadRegistryVersionInvalid ReadRegistryVersion = iota
+
+	// ReadRegistryVersionNoType specifies a read registry instruction that
+	// doesn't return the type of the fetched entry at the end of the output.
+	ReadRegistryVersionNoType
+
+	// ReadRegistryVersionWithType specifies a read registry instruction that
+	// returns the type of the fetched entry at the end of the output.
+	ReadRegistryVersionWithType
 )
 
 const (
@@ -135,10 +151,21 @@ const (
 	// tweakOffset + pubKeyOffset + pubKeyLength = 3 * 8 bytes = 24 byte
 	RPCIReadRegistryLen = 24
 
+	// RPCIReadRegistryWithVersionLen is the expected length of the 'Args' of an
+	// ReadRegistry instruction.
+	// tweakOffset + pubKeyOffset + pubKeyLength + version = 3 * 8 bytes + 1 =
+	// 25 byte
+	RPCIReadRegistryWithVersionLen = 25
+
 	// RPCIReadRegistryEIDLen is the expected length of the 'Args' of an
 	// ReadRegistryEID instruction.
 	// sidOffset = 8 bytes + pubkey bool 1 byte
 	RPCIReadRegistryEIDLen = 9
+
+	// RPCIReadRegistryEIDWithVersionLen is the expected length of the 'Args' of
+	// an ReadRegistryEID instruction.
+	// sidOffset = 8 bytes + pubkey bool 1 byte + 1 version byte
+	RPCIReadRegistryEIDWithVersionLen = 10
 )
 
 var (

--- a/modules/renter/workerjobreadregistry.go
+++ b/modules/renter/workerjobreadregistry.go
@@ -75,8 +75,10 @@ func lookupRegistry(w *worker, spk types.SiaPublicKey, tweak crypto.Hash) (*modu
 	var err error
 	if build.VersionCmp(w.staticCache().staticHostVersion, "1.5.5") < 0 {
 		refund, err = pb.V154AddReadRegistryInstruction(spk, tweak)
+	} else if build.VersionCmp(w.staticCache().staticHostVersion, "1.5.6") < 0 {
+		refund, err = pb.V156AddReadRegistryInstruction(spk, tweak)
 	} else {
-		refund, err = pb.AddReadRegistryInstruction(spk, tweak)
+		refund, err = pb.AddReadRegistryInstruction(spk, tweak, modules.ReadRegistryVersionNoType)
 	}
 	if err != nil {
 		return nil, errors.AddContext(err, "Unable to add read registry instruction")

--- a/modules/renter/workerjobupdateregistry.go
+++ b/modules/renter/workerjobupdateregistry.go
@@ -186,6 +186,8 @@ func (j *jobUpdateRegistry) managedUpdateRegistry() (modules.SignedRegistryValue
 	pb := modules.NewProgramBuilder(&pt, 0) // 0 duration since UpdateRegistry doesn't depend on it.
 	if build.VersionCmp(w.staticCache().staticHostVersion, "1.5.5") < 0 {
 		pb.V154AddUpdateRegistryInstruction(j.staticSiaPublicKey, j.staticSignedRegistryValue)
+	} else if build.VersionCmp(w.staticCache().staticHostVersion, "1.5.6") < 0 {
+		pb.V156AddUpdateRegistryInstruction(j.staticSiaPublicKey, j.staticSignedRegistryValue)
 	} else {
 		pb.AddUpdateRegistryInstruction(j.staticSiaPublicKey, j.staticSignedRegistryValue)
 	}


### PR DESCRIPTION
This MR is hopefully the last one related to the new registry entries.

Similar to how we extended the update instruction, this extends the read instruction to inform the reader of the type of the entry. That's important for being able to verify the signature correctly.