### PR TITLE
Improve Performance of Some Tests in `siatest/renter`

### DIFF
--- a/siatest/renter/backup_test.go
+++ b/siatest/renter/backup_test.go
@@ -202,7 +202,7 @@ func TestInterruptBackup(t *testing.T) {
 
 	// Create a testgroup.
 	groupParams := siatest.GroupParams{
-		Hosts:   5,
+		Hosts:   3,
 		Miners:  1,
 		Renters: 1,
 	}
@@ -300,7 +300,6 @@ func TestRemoteBackup(t *testing.T) {
 	filesSize := int(20e3)
 
 	// Create a testgroup.
-	//
 	// Need 5 hosts to address an NDF with the snapshot upload code.
 	groupParams := siatest.GroupParams{
 		Hosts:   5,

--- a/siatest/renter/hostdb/hostdb_test.go
+++ b/siatest/renter/hostdb/hostdb_test.go
@@ -683,7 +683,7 @@ func TestFilterMode(t *testing.T) {
 
 	// Create a group for testing
 	groupParams := siatest.GroupParams{
-		Hosts:  10,
+		Hosts:  6,
 		Miners: 1,
 	}
 	testDir := hostdbTestDir(t.Name())
@@ -697,12 +697,12 @@ func TestFilterMode(t *testing.T) {
 		}
 	}()
 
-	// Create renter. Set allowance of 2 with 10 total hosts, this will allow a
+	// Create renter. Set allowance of 2 with 6 total hosts, this will allow a
 	// blacklist or whitelist of 2, and a number of extra hosts to potentially
 	// cancel contracts with
 	renterParams := node.Renter(testDir + "/renter")
 	renterParams.Allowance = siatest.DefaultAllowance
-	renterParams.Allowance.Hosts = uint64(2)
+	renterParams.Allowance.Hosts = 2
 	nodes, err := tg.AddNodes(renterParams)
 	if err != nil {
 		t.Fatal(err)

--- a/siatest/renter/renter_test.go
+++ b/siatest/renter/renter_test.go
@@ -60,6 +60,8 @@ func TestRenterOne(t *testing.T) {
 		{Name: "TestDirectories", Test: testDirectories},
 		{Name: "TestAlertsSorted", Test: testAlertsSorted},
 		{Name: "TestPriceTablesUpdated", Test: testPriceTablesUpdated},
+		{Name: "TestFileAvailableAndRecoverable", Test: testFileAvailableAndRecoverable},
+		{Name: "TestReceivedFieldEqualsFileSize", Test: testReceivedFieldEqualsFileSize},
 	}
 
 	// Run tests
@@ -78,7 +80,7 @@ func TestRenterTwo(t *testing.T) {
 
 	// Create a group for the subtests
 	groupParams := siatest.GroupParams{
-		Hosts:   5,
+		Hosts:   3,
 		Renters: 1,
 		Miners:  1,
 	}
@@ -86,7 +88,6 @@ func TestRenterTwo(t *testing.T) {
 
 	// Specify subtests to run
 	subTests := []siatest.SubTest{
-		{Name: "TestReceivedFieldEqualsFileSize", Test: testReceivedFieldEqualsFileSize},
 		{Name: "TestRemoteRepair", Test: testRemoteRepair},
 		{Name: "TestSingleFileGet", Test: testSingleFileGet},
 		{Name: "TestSiaFileTimestamps", Test: testSiafileTimestamps},
@@ -235,7 +236,7 @@ func TestRenterThree(t *testing.T) {
 
 	// Create a group for the subtests
 	groupParams := siatest.GroupParams{
-		Hosts:   5,
+		Hosts:   3,
 		Renters: 1,
 		Miners:  1,
 	}
@@ -244,7 +245,6 @@ func TestRenterThree(t *testing.T) {
 	// Specify subtests to run
 	subTests := []siatest.SubTest{
 		{Name: "TestAllowanceDefaultSet", Test: testAllowanceDefaultSet},
-		{Name: "TestFileAvailableAndRecoverable", Test: testFileAvailableAndRecoverable},
 		{Name: "TestSetFileStuck", Test: testSetFileStuck},
 		{Name: "TestCancelAsyncDownload", Test: testCancelAsyncDownload},
 		{Name: "TestUploadDownload", Test: testUploadDownload}, // Needs to be last as it impacts hosts
@@ -266,7 +266,7 @@ func TestRenterFour(t *testing.T) {
 
 	// Create a group for the subtests
 	groupParams := siatest.GroupParams{
-		Hosts:   5,
+		Hosts:   2,
 		Renters: 1,
 		Miners:  1,
 	}
@@ -1885,7 +1885,7 @@ func TestRenterAddNodes2(t *testing.T) {
 
 	// Create a group for testing
 	groupParams := siatest.GroupParams{
-		Hosts:   5,
+		Hosts:   4,
 		Renters: 1,
 		Miners:  1,
 	}
@@ -3176,7 +3176,7 @@ func TestSetFileTrackingPath(t *testing.T) {
 
 	// Create a testgroup.
 	gp := siatest.GroupParams{
-		Hosts:   5,
+		Hosts:   3,
 		Renters: 1,
 		Miners:  1,
 	}


### PR DESCRIPTION
This pull request improves the performance of various tests in `siatest/renter`.  Many tests in this directory have large initialization times due to having to initialize many test hosts.  This pull request lowers the amount of test hosts created in tests where it was unnecessarily high which improves performance in these tests by about 20-30%.