### PR TITLE
add block height to modules.ConsensusChange

### DIFF
--- a/cmd/siac/maincmd_test.go
+++ b/cmd/siac/maincmd_test.go
@@ -77,7 +77,7 @@ Renter Rate limits:
   Download Speed: (no limit|\d+(\.\d+)? (B/s|KB/s|MB/s|GB/s|TB/s))
   Upload Speed:   (no limit|\d+(\.\d+)? (B/s|KB/s|MB/s|GB/s|TB/s))`
 
-	connectionRefusedPattern := `Could not get consensus status: \[failed to get reader response; GET request failed; Get "?http://localhost:5555/consensus"?: dial tcp \[::1\]:5555: connect: connection refused\]`
+	connectionRefusedPattern := `Could not get consensus status: \[failed to get reader response; GET request failed; Get "?http://localhost:5555/consensus"?: dial tcp (127\.0\.0\.1|\[::1\]):5555: connect: connection refused\]`
 	siaClientVersionPattern := "siac v" + escapeRegexChars(build.NodeVersion)
 
 	// Define subtests

--- a/modules/consensus.go
+++ b/modules/consensus.go
@@ -93,6 +93,10 @@ type (
 		// and applied blocks.
 		ID ConsensusChangeID
 
+		// BlockHeight is the height of the chain after all blocks included in
+		// this change have been reverted and applied.
+		BlockHeight types.BlockHeight
+
 		// RevertedBlocks is the list of blocks that were reverted by the change.
 		// The reverted blocks were always all reverted before the applied blocks
 		// were applied. The revered blocks are presented in the order that they

--- a/modules/consensus.go
+++ b/modules/consensus.go
@@ -272,6 +272,14 @@ func (cc *ConsensusChange) AppendDiffs(diffs ConsensusChangeDiffs) {
 	cc.SiafundPoolDiffs = append(cc.SiafundPoolDiffs, diffs.SiafundPoolDiffs...)
 }
 
+// InitialHeight returns the height of the consensus before blocks are applied.
+func (cc *ConsensusChange) InitialHeight() types.BlockHeight {
+	if cc.BlockHeight == 0 {
+		return 0
+	}
+	return cc.BlockHeight - types.BlockHeight(len(cc.AppliedBlocks))
+}
+
 // MarshalSia implements encoding.SiaMarshaler.
 func (cc ConsensusChange) MarshalSia(w io.Writer) error {
 	return encoding.NewEncoder(w).EncodeAll(

--- a/modules/consensus/subscribe.go
+++ b/modules/consensus/subscribe.go
@@ -91,8 +91,10 @@ func (cs *ConsensusSet) computeConsensusChange(tx *bolt.Tx, ce changeEntry) (mod
 	if err != nil {
 		cs.log.Critical("could not find process block for known block")
 	}
+
 	cc.ChildTarget = pb.ChildTarget
 	cc.MinimumValidChildTimestamp = cs.blockRuleHelper.minimumValidChildTimestamp(tx.Bucket(BlockMap), pb)
+	cc.BlockHeight = pb.Height
 
 	currentBlock := currentBlockID(tx)
 	if cs.synced && recentBlock == currentBlock {

--- a/modules/explorer/update.go
+++ b/modules/explorer/update.go
@@ -114,13 +114,7 @@ func (e *Explorer) ProcessConsensusChange(cc modules.ConsensusChange) {
 			dbRemoveBlockFacts(tx, bid)
 		}
 
-		// Calculate the block height before blocks are applied. If this is the
-		// genesis change, set the height to 0.
-		blockheight := cc.BlockHeight - types.BlockHeight(len(cc.AppliedBlocks))
-		if cc.BlockHeight == 0 {
-			blockheight = 0
-		}
-
+		blockheight := cc.InitialHeight()
 		// Update cumulative stats for applied blocks.
 		for _, block := range cc.AppliedBlocks {
 			bid := block.ID()

--- a/modules/host/accountmanager.go
+++ b/modules/host/accountmanager.go
@@ -410,7 +410,7 @@ func (am *accountManager) callWithdraw(msg *modules.WithdrawalMessage, sig crypt
 
 // callConsensusChanged is called by the host whenever it processed a change to
 // the consensus. We use it to remove fingerprints which have been expired.
-func (am *accountManager) callConsensusChanged(cc modules.ConsensusChange, oldHeight, newHeight types.BlockHeight) {
+func (am *accountManager) callConsensusChanged(cc modules.ConsensusChange, oldHeight types.BlockHeight) {
 	am.mu.Lock()
 	defer am.mu.Unlock()
 
@@ -430,9 +430,9 @@ func (am *accountManager) callConsensusChanged(cc modules.ConsensusChange, oldHe
 	// new height due to blockchain reorgs that could cause the blockheight
 	// to increase (or decrease) by multiple blocks at a time, potentially
 	// skipping over the min height of the bucket.
-	min, _ := currentBucketRange(newHeight)
+	min, _ := currentBucketRange(cc.BlockHeight)
 	withdrawalsActive := !am.withdrawalsInactive
-	shouldRotate := oldHeight < newHeight && oldHeight < min && min <= newHeight
+	shouldRotate := oldHeight < cc.BlockHeight && oldHeight < min && min <= cc.BlockHeight
 	if withdrawalsActive && !shouldRotate {
 		return
 	}

--- a/modules/host/accountmanager_test.go
+++ b/modules/host/accountmanager_test.go
@@ -1152,7 +1152,7 @@ func TestAccountWithdrawalsInactive(t *testing.T) {
 	}
 
 	// Mock a consensus change that indicates the host is not synced
-	am.callConsensusChanged(modules.ConsensusChange{Synced: false}, 0, 1)
+	am.callConsensusChanged(modules.ConsensusChange{Synced: false, BlockHeight: 1}, 0)
 
 	// Verify withdrawal is active
 	msg, sig = prepareWithdrawal(accountID, oneCurrency, am.h.blockHeight, sk)

--- a/modules/host/update.go
+++ b/modules/host/update.go
@@ -200,13 +200,7 @@ func (h *Host) ProcessConsensusChange(cc modules.ConsensusChange) {
 			}
 		}
 
-		// Calculate the block height before blocks are applied. If this is the
-		// genesis block, set the height to 0.
-		h.blockHeight = cc.BlockHeight - types.BlockHeight(len(cc.AppliedBlocks))
-		if cc.BlockHeight == 0 {
-			h.blockHeight = 0
-		}
-
+		h.blockHeight = cc.InitialHeight()
 		for _, block := range cc.AppliedBlocks {
 			// Look for transactions relevant to open storage obligations.
 			for _, txn := range block.Transactions {

--- a/modules/miner/update.go
+++ b/modules/miner/update.go
@@ -256,32 +256,7 @@ func (m *Miner) ProcessConsensusChange(cc modules.ConsensusChange) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	// Update the miner's understanding of the block height.
-	for _, block := range cc.RevertedBlocks {
-		// Only doing the block check if the height is above zero saves hashing
-		// and saves a nontrivial amount of time during IBD.
-		if m.persist.Height > 0 || block.ID() != types.GenesisID {
-			m.persist.Height--
-		} else if m.persist.Height != 0 {
-			// Sanity check - if the current block is the genesis block, the
-			// miner height should be set to zero.
-			m.log.Critical("Miner has detected a genesis block, but the height of the miner is set to ", m.persist.Height)
-			m.persist.Height = 0
-		}
-	}
-	for _, block := range cc.AppliedBlocks {
-		// Only doing the block check if the height is above zero saves hashing
-		// and saves a nontrivial amount of time during IBD.
-		if m.persist.Height > 0 || block.ID() != types.GenesisID {
-			m.persist.Height++
-		} else if m.persist.Height != 0 {
-			// Sanity check - if the current block is the genesis block, the
-			// miner height should be set to zero.
-			m.log.Critical("Miner has detected a genesis block, but the height of the miner is set to ", m.persist.Height)
-			m.persist.Height = 0
-		}
-	}
-
+	m.persist.Height = cc.BlockHeight
 	// Update the unsolved block.
 	m.persist.UnsolvedBlock.ParentID = cc.AppliedBlocks[len(cc.AppliedBlocks)-1].ID()
 	m.persist.Target = cc.ChildTarget

--- a/modules/renter/contractor/recovery.go
+++ b/modules/renter/contractor/recovery.go
@@ -83,11 +83,9 @@ func (rs *recoveryScanner) ProcessConsensusChange(cc modules.ConsensusChange) {
 		rs.c.mu.Lock()
 		rs.c.findRecoverableContracts(rs.rs, block)
 		rs.c.mu.Unlock()
-		atomic.AddInt64(&rs.c.atomicRecoveryScanHeight, 1)
 	}
-	for range cc.RevertedBlocks {
-		atomic.AddInt64(&rs.c.atomicRecoveryScanHeight, -1)
-	}
+
+	atomic.StoreInt64(&rs.c.atomicRecoveryScanHeight, int64(cc.BlockHeight))
 	// Update the recentRecoveryChange
 	rs.c.mu.Lock()
 	rs.c.recentRecoveryChange = cc.ID

--- a/modules/renter/contractor/update.go
+++ b/modules/renter/contractor/update.go
@@ -94,13 +94,7 @@ func (c *Contractor) ProcessConsensusChange(cc modules.ConsensusChange) {
 		c.removeRecoverableContracts(block)
 	}
 
-	// Calculate the height before the blocks were applied. If this is the
-	// genesis change set the height to 0.
-	c.blockHeight = cc.BlockHeight - types.BlockHeight(len(cc.AppliedBlocks))
-	if cc.BlockHeight == 0 {
-		c.blockHeight = 0
-	}
-
+	c.blockHeight = cc.InitialHeight()
 	for _, block := range cc.AppliedBlocks {
 		if block.ID() != types.GenesisID {
 			c.blockHeight++

--- a/modules/renter/contractor/update.go
+++ b/modules/renter/contractor/update.go
@@ -90,12 +90,17 @@ func (c *Contractor) ProcessConsensusChange(cc modules.ConsensusChange) {
 
 	c.mu.Lock()
 	for _, block := range cc.RevertedBlocks {
-		if block.ID() != types.GenesisID {
-			c.blockHeight--
-		}
 		// Remove recoverable contracts found in reverted block.
 		c.removeRecoverableContracts(block)
 	}
+
+	// Calculate the height before the blocks were applied. If this is the
+	// genesis change set the height to 0.
+	c.blockHeight = cc.BlockHeight - types.BlockHeight(len(cc.AppliedBlocks))
+	if cc.BlockHeight == 0 {
+		c.blockHeight = 0
+	}
+
 	for _, block := range cc.AppliedBlocks {
 		if block.ID() != types.GenesisID {
 			c.blockHeight++

--- a/modules/transactionpool/update.go
+++ b/modules/transactionpool/update.go
@@ -205,9 +205,6 @@ func (tp *TransactionPool) ProcessConsensusChange(cc modules.ConsensusChange) {
 		}
 		recentID = block.ParentID
 
-		if tp.blockHeight > 0 || block.ID() != types.GenesisID {
-			tp.blockHeight--
-		}
 		for _, txn := range block.Transactions {
 			err := tp.deleteTransaction(tp.dbTx, txn.ID())
 			if err != nil {
@@ -224,6 +221,7 @@ func (tp *TransactionPool) ProcessConsensusChange(cc modules.ConsensusChange) {
 			tp.recentMedians = tp.recentMedians[:len(tp.recentMedians)-1]
 		}
 	}
+
 	for _, block := range cc.AppliedBlocks {
 		// Sanity check - the parent id of each block should match the current
 		// block id.
@@ -232,9 +230,6 @@ func (tp *TransactionPool) ProcessConsensusChange(cc modules.ConsensusChange) {
 		}
 		recentID = block.ID()
 
-		if tp.blockHeight > 0 || block.ID() != types.GenesisID {
-			tp.blockHeight++
-		}
 		for _, txn := range block.Transactions {
 			err := tp.putTransaction(tp.dbTx, txn.ID())
 			if err != nil {
@@ -308,6 +303,7 @@ func (tp *TransactionPool) ProcessConsensusChange(cc modules.ConsensusChange) {
 	tp.recentMedianFee = safeMedians[len(safeMedians)/2]
 
 	// Update all the on-disk structures.
+	tp.blockHeight = cc.BlockHeight
 	err = tp.putRecentConsensusChange(tp.dbTx, cc.ID)
 	if err != nil {
 		tp.log.Println("ERROR: could not update the recent consensus change:", err)

--- a/modules/wallet/scan.go
+++ b/modules/wallet/scan.go
@@ -138,7 +138,7 @@ func (s *seedScanner) ProcessConsensusChange(cc modules.ConsensusChange) {
 		}
 	}
 	// Adjust the scanned height and print the scan progress.
-	s.scannedHeight += types.BlockHeight(len(cc.AppliedBlocks) - len(cc.RevertedBlocks))
+	s.scannedHeight = cc.BlockHeight
 	if !cc.Synced {
 		fmt.Printf("\rWallet: scanned to height %d...", s.scannedHeight)
 	} else {

--- a/modules/wallet/update.go
+++ b/modules/wallet/update.go
@@ -474,12 +474,7 @@ func (w *Wallet) computeProcessedTransactionsFromBlock(tx *bolt.Tx, block types.
 func (w *Wallet) applyHistory(tx *bolt.Tx, cc modules.ConsensusChange) error {
 	spentSiacoinOutputs := computeSpentSiacoinOutputSet(cc.SiacoinOutputDiffs)
 	spentSiafundOutputs := computeSpentSiafundOutputSet(cc.SiafundOutputDiffs)
-	// Calculate the consensus height before blocks are applied by this change.
-	// If this is the genesis block, height will be 0.
-	consensusHeight := cc.BlockHeight - types.BlockHeight(len(cc.AppliedBlocks))
-	if cc.BlockHeight == 0 {
-		consensusHeight = 0
-	}
+	consensusHeight := cc.InitialHeight()
 
 	for _, block := range cc.AppliedBlocks {
 		// Increment the consensus height.

--- a/modules/wallet/update.go
+++ b/modules/wallet/update.go
@@ -196,18 +196,6 @@ func (w *Wallet) revertHistory(tx *bolt.Tx, reverted []types.Block) error {
 				break // there will only ever be one miner transaction
 			}
 		}
-
-		// decrement the consensus height
-		if block.ID() != types.GenesisID {
-			consensusHeight, err := dbGetConsensusHeight(tx)
-			if err != nil {
-				return err
-			}
-			err = dbPutConsensusHeight(tx, consensusHeight-1)
-			if err != nil {
-				return err
-			}
-		}
 	}
 	return nil
 }
@@ -486,19 +474,17 @@ func (w *Wallet) computeProcessedTransactionsFromBlock(tx *bolt.Tx, block types.
 func (w *Wallet) applyHistory(tx *bolt.Tx, cc modules.ConsensusChange) error {
 	spentSiacoinOutputs := computeSpentSiacoinOutputSet(cc.SiacoinOutputDiffs)
 	spentSiafundOutputs := computeSpentSiafundOutputSet(cc.SiafundOutputDiffs)
+	// Calculate the consensus height before blocks are applied by this change.
+	// If this is the genesis block, height will be 0.
+	consensusHeight := cc.BlockHeight - types.BlockHeight(len(cc.AppliedBlocks))
+	if cc.BlockHeight == 0 {
+		consensusHeight = 0
+	}
 
 	for _, block := range cc.AppliedBlocks {
-		consensusHeight, err := dbGetConsensusHeight(tx)
-		if err != nil {
-			return errors.AddContext(err, "failed to consensus height")
-		}
 		// Increment the consensus height.
 		if block.ID() != types.GenesisID {
 			consensusHeight++
-			err = dbPutConsensusHeight(tx, consensusHeight)
-			if err != nil {
-				return errors.AddContext(err, "failed to store consensus height in database")
-			}
 		}
 
 		pts := w.computeProcessedTransactionsFromBlock(tx, block, spentSiacoinOutputs, spentSiafundOutputs, consensusHeight)
@@ -544,6 +530,10 @@ func (w *Wallet) ProcessConsensusChange(cc modules.ConsensusChange) {
 	}
 	if err := dbPutConsensusChangeID(w.dbTx, cc.ID); err != nil {
 		w.log.Severe("ERROR: failed to update consensus change ID:", err)
+		w.dbRollback = true
+	}
+	if err := dbPutConsensusHeight(w.dbTx, cc.BlockHeight); err != nil {
+		w.log.Severe("ERROR: failed to update consensus block height:", err)
 		w.dbRollback = true
 	}
 

--- a/modules/wallet/update_test.go
+++ b/modules/wallet/update_test.go
@@ -47,6 +47,7 @@ func TestUpdate(t *testing.T) {
 	// revert the block
 	wt.wallet.ProcessConsensusChange(modules.ConsensusChange{
 		RevertedBlocks: []types.Block{b},
+		BlockHeight:    8,
 	})
 	// transaction should no longer be present
 	_, ok, err = wt.wallet.Transaction(types.TransactionID(b.ID()))
@@ -65,7 +66,9 @@ func TestUpdate(t *testing.T) {
 	}
 
 	// mine blocks until transaction is confirmed, while building up a cc that will revert all the blocks we add
-	var revertCC modules.ConsensusChange
+	revertCC := modules.ConsensusChange{
+		BlockHeight: 11,
+	}
 	for i := types.BlockHeight(0); i <= types.MaturityDelay; i++ {
 		b, _ := wt.miner.FindBlock()
 		if err := wt.cs.AcceptBlock(b); err != nil {


### PR DESCRIPTION
Adds `BlockHeight` to `modules.ConsensusChange` and updates all existing consensus subscribers to use it.

## Explorer
Only needs to calculate the height before changes are applied and increments it so each block added to the explorer corresponds to the correct height.

## Host
Calculates the height before blocks are applied then increments it for each applied block so that action items are properly handled.

### Account manager
Changes `AccountManager.callConsensusChanged` to only pass the old height and use `ConsensusChange.BlockHeight` for the new height.

## Miner
Uses `ConsensusChange.Blockheight` directly, just needs to know the height to calculate the correct block subsidy.

## Renter

### Contractor
Calculates the height before blocks are applied and increments it for each applied block so `Contractor.findRecoverableContracts` can set start height.

### Recovery scanner
Changes `atomicRecoveryScanHeight` to be set directly to `cc.BlockHeight` instead of calculated. It's only used to print the recovery status.

### Host DB
Sets the host db's block height to `cc.BlockHeight` before checking for host announcements to preserve its existing behavior.

## Transaction pool
Sets `tp.blockHeight` after reverting and applying the blocks since the loops are not dependent on `tp.blockHeight`.

## Wallet
Calculates the height before blocks are applied in `applyHistory`, then sets the height once in `ProcessConsensusChange`. Removes the need for `dbGetConsensusHeight` in `applyHistory`, `revertHistory`, and `ProcessConsensusChange`.

Closes #24 