### PR TITLE
Fix panic in SiaPublicKey.String() for long key

### DIFF
--- a/types/encoding.go
+++ b/types/encoding.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"bytes"
+	"crypto/ed25519"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -582,8 +583,8 @@ func (spk *SiaPublicKey) LoadString(s string) error {
 // compact during logging. The key type prefix and lack of a checksum help to
 // separate it from a sia address.
 func (spk SiaPublicKey) String() string {
-	if spk.Algorithm == SignatureEd25519 {
-		buf := make([]byte, 72)
+	if spk.Algorithm == SignatureEd25519 && len(spk.Key) == ed25519.PublicKeySize {
+		buf := make([]byte, 8+2*ed25519.PublicKeySize)
 		copy(buf[:8], "ed25519:")
 		hex.Encode(buf[8:], spk.Key)
 		return string(buf)

--- a/types/encoding_test.go
+++ b/types/encoding_test.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"bytes"
+	"crypto/ed25519"
 	"encoding/json"
 	"fmt"
 	"math/big"
@@ -491,6 +492,14 @@ func TestSiaPublicKeyString(t *testing.T) {
 	}
 
 	if spk.String() != "ed25519:0000000000000000000000000000000000000000000000000000000000000000" {
+		t.Error("got wrong value for spk.String():", spk.String())
+	}
+
+	// Try long key. This shouldn't panic.
+	spk.Algorithm = SignatureEd25519
+	spk.Key = make([]byte, ed25519.PublicKeySize+1)
+
+	if spk.String() != "ed25519:000000000000000000000000000000000000000000000000000000000000000000" {
 		t.Error("got wrong value for spk.String():", spk.String())
 	}
 }


### PR DESCRIPTION
This fixes a panic in `SiaPublicKey.String` which occurred when the key was too long and the algorithm was set to ed25519.