### PR TITLE
Return entry type in proof response of new UpdateRegistry instruction

### DIFF
--- a/modules/host/rpcexecuteprogram_test.go
+++ b/modules/host/rpcexecuteprogram_test.go
@@ -1376,8 +1376,9 @@ func TestExecuteUpdateRegistryProgram(t *testing.T) {
 	var sig2 crypto.Signature
 	copy(sig2[:], resp.Output[:crypto.SignatureSize])
 	rev2 := binary.LittleEndian.Uint64(resp.Output[crypto.SignatureSize:])
-	data2 := resp.Output[crypto.SignatureSize+8:]
-	rv2 := modules.NewSignedRegistryValue(tweak, data2, rev2, sig2, modules.RegistryTypeWithoutPubkey)
+	data2 := resp.Output[crypto.SignatureSize+8 : len(resp.Output)-1]
+	entryType := modules.RegistryEntryType(resp.Output[len(resp.Output)-1])
+	rv2 := modules.NewSignedRegistryValue(tweak, data2, rev2, sig2, entryType)
 	if !reflect.DeepEqual(rv, rv2) {
 		t.Log(rv)
 		t.Log(rv2)
@@ -1447,8 +1448,9 @@ func TestExecuteUpdateRegistryProgram(t *testing.T) {
 	// Parse response.
 	copy(sig2[:], resp.Output[:crypto.SignatureSize])
 	rev2 = binary.LittleEndian.Uint64(resp.Output[crypto.SignatureSize:])
-	data2 = resp.Output[crypto.SignatureSize+8:]
-	rv2 = modules.NewSignedRegistryValue(tweak, data2, rev2, sig2, modules.RegistryTypeWithoutPubkey)
+	data2 = resp.Output[crypto.SignatureSize+8 : len(resp.Output)-1]
+	entryType = modules.RegistryEntryType(resp.Output[len(resp.Output)-1])
+	rv2 = modules.NewSignedRegistryValue(tweak, data2, rev2, sig2, entryType)
 	if !reflect.DeepEqual(rv, rv2) {
 		t.Log(rv)
 		t.Log(rv2)

--- a/modules/renter/workerjobupdateregistry.go
+++ b/modules/renter/workerjobupdateregistry.go
@@ -184,11 +184,13 @@ func (j *jobUpdateRegistry) managedUpdateRegistry() (modules.SignedRegistryValue
 	// Create the program.
 	pt := w.staticPriceTable().staticPriceTable
 	pb := modules.NewProgramBuilder(&pt, 0) // 0 duration since UpdateRegistry doesn't depend on it.
+	version := modules.ReadRegistryVersionNoType
 	if build.VersionCmp(w.staticCache().staticHostVersion, "1.5.5") < 0 {
 		pb.V154AddUpdateRegistryInstruction(j.staticSiaPublicKey, j.staticSignedRegistryValue)
 	} else if build.VersionCmp(w.staticCache().staticHostVersion, "1.5.6") < 0 {
 		pb.V156AddUpdateRegistryInstruction(j.staticSiaPublicKey, j.staticSignedRegistryValue)
 	} else {
+		version = modules.ReadRegistryVersionWithType
 		pb.AddUpdateRegistryInstruction(j.staticSiaPublicKey, j.staticSignedRegistryValue)
 	}
 	program, programData := pb.Program()
@@ -221,7 +223,8 @@ func (j *jobUpdateRegistry) managedUpdateRegistry() (modules.SignedRegistryValue
 		}
 		if modules.IsRegistryEntryExistErr(err) {
 			// Parse the proof.
-			rv, parseErr := parseSignedRegistryValueResponse(resp.Output, j.staticSignedRegistryValue.Tweak, modules.RegistryTypeWithoutPubkey)
+			_, _, data, revision, sig, entryType, parseErr := parseSignedRegistryValueResponse(resp.Output, false, version)
+			rv := modules.NewSignedRegistryValue(j.staticSignedRegistryValue.Tweak, data, revision, sig, entryType)
 			return rv, errors.Compose(err, parseErr)
 		}
 		if err != nil {

--- a/modules/renter/workerjobupdateregistry_test.go
+++ b/modules/renter/workerjobupdateregistry_test.go
@@ -105,14 +105,14 @@ func TestUpdateRegistryJob(t *testing.T) {
 	deps.Fail()
 	err = wt.UpdateRegistry(context.Background(), spk, rv)
 	deps.Disable()
-	if !errors.Contains(err, crypto.ErrInvalidSignature) {
+	if !errors.Contains(err, crypto.ErrInvalidSignature) && !errors.Contains(err, modules.ErrUnknownRegistryEntryType) {
 		t.Fatal(err)
 	}
 
-	// Make sure the recent error is an invalid signature error and reset the
-	// cooldown.
+	// Make sure the recent error is an invalid signature error or unknown
+	// entry error and reset the cooldown.
 	wt.staticJobUpdateRegistryQueue.mu.Lock()
-	if !errors.Contains(wt.staticJobUpdateRegistryQueue.recentErr, crypto.ErrInvalidSignature) {
+	if !errors.Contains(wt.staticJobUpdateRegistryQueue.recentErr, crypto.ErrInvalidSignature) && !errors.Contains(err, modules.ErrUnknownRegistryEntryType) {
 		t.Fatal(err)
 	}
 	if wt.staticJobUpdateRegistryQueue.cooldownUntil == (time.Time{}) {
@@ -147,7 +147,7 @@ func TestUpdateRegistryJob(t *testing.T) {
 	deps.Fail()
 	err = wt.UpdateRegistry(context.Background(), spk, rvLowRevNum)
 	deps.Disable()
-	if !errors.Contains(err, crypto.ErrInvalidSignature) {
+	if !errors.Contains(err, crypto.ErrInvalidSignature) && !errors.Contains(err, modules.ErrUnknownRegistryEntryType) {
 		t.Fatal(err)
 	}
 	if modules.IsRegistryEntryExistErr(err) {
@@ -157,7 +157,7 @@ func TestUpdateRegistryJob(t *testing.T) {
 	// Make sure the recent error is an invalid signature error and reset the
 	// cooldown.
 	wt.staticJobUpdateRegistryQueue.mu.Lock()
-	if !errors.Contains(wt.staticJobUpdateRegistryQueue.recentErr, crypto.ErrInvalidSignature) {
+	if !errors.Contains(wt.staticJobUpdateRegistryQueue.recentErr, crypto.ErrInvalidSignature) && !errors.Contains(err, modules.ErrUnknownRegistryEntryType) {
 		t.Fatal(err)
 	}
 	if modules.IsRegistryEntryExistErr(err) {


### PR DESCRIPTION
This MR updates the UpdateRegistry instruction to return the entry type in case a registry entry needs to be returned for a proof. For backwards compatibility it is only returned for the new UpdateRegistry instruction and not the pre 1.5.6 one.