### PR TITLE
Fix release scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
 # These variables get inserted into ./build/commit.go
-BUILD_TIME=$(shell date)
 GIT_REVISION=$(shell git rev-parse --short HEAD)
 GIT_DIRTY=$(shell git diff-index --quiet HEAD -- || echo "✗-")
+ifeq ("$(GIT_DIRTY)", "✗-")
+	BUILD_TIME=$(shell date)
+else
+	BUILD_TIME=$(shell git show -s --format=%ci HEAD)
+endif
 
 ldflags= \
 -X "go.sia.tech/siad/build.BinaryName=siad" \

--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ dev-race:
 	GORACE='$(racevars)' go install -race -tags='dev debug profile netgo' -ldflags='$(ldflags)' $(pkgs)
 
 static:
-	go build -o release/ -tags='netgo' -ldflags='-s -w $(ldflags)' $(release-pkgs)
+	go build -trimpath -o release/ -tags='netgo' -ldflags='-s -w $(ldflags)' $(release-pkgs)
 
 # release builds and installs release binaries.
 release:

--- a/build/version.go
+++ b/build/version.go
@@ -22,10 +22,6 @@ var (
 	// NodeVersion is the current version of the node software. It is supplied
 	// at compile time via ldflags.
 	NodeVersion string = "?.?.?"
-
-	// ReleaseTag contains the release tag, such as "rc3". It is supplied at build
-	// time. For full releases, this string is blank.
-	ReleaseTag string = "master"
 )
 
 // IsVersion returns whether str is a valid version number.

--- a/build/version.go
+++ b/build/version.go
@@ -24,7 +24,7 @@ var (
 	NodeVersion string = "?.?.?"
 )
 
-// IsVersion returns whether str is a valid version number.
+// IsVersion returns whether str is a valid release version with no -rc component.
 func IsVersion(str string) bool {
 	for _, n := range strings.Split(str, ".") {
 		if _, err := strconv.Atoi(n); err != nil {
@@ -42,6 +42,24 @@ func min(a, b int) int {
 	return b
 }
 
+// splitVersion splits a version string into it's version and optional rc component.
+// full releases are considered rc 0.
+func splitVersion(v string) (version []int, rc int) {
+	parts := strings.Split(v, "-rc")
+	for _, s := range strings.Split(parts[0], ".") {
+		n, _ := strconv.Atoi(s)
+		version = append(version, n)
+	}
+	if len(parts) == 1 { // if we don't have an rc part, we're done
+		return
+	} else if len(parts[1]) == 0 { // -rc is equivalent to -rc1 since rc0 is a full release
+		return version, 1
+	}
+
+	rc, _ = strconv.Atoi(parts[1])
+	return
+}
+
 // VersionCmp returns an int indicating the difference between a and b. It
 // follows the convention of bytes.Compare and big.Cmp:
 //
@@ -52,24 +70,33 @@ func min(a, b int) int {
 // One important quirk is that "1.1.0" is considered newer than "1.1", despite
 // being numerically equal.
 func VersionCmp(a, b string) int {
-	aNums := strings.Split(a, ".")
-	bNums := strings.Split(b, ".")
-	for i := 0; i < min(len(aNums), len(bNums)); i++ {
-		// assume that both version strings are valid
-		aInt, _ := strconv.Atoi(aNums[i])
-		bInt, _ := strconv.Atoi(bNums[i])
-		if aInt < bInt {
+	va, rca := splitVersion(a)
+	vb, rcb := splitVersion(b)
+
+	for i := 0; i < min(len(va), len(vb)); i++ {
+		if va[i] < vb[i] {
 			return -1
-		} else if aInt > bInt {
+		} else if va[i] > vb[i] {
 			return 1
 		}
 	}
-	// all shared digits are equal, but lengths may not be equal
-	if len(aNums) < len(bNums) {
+
+	switch {
+	case len(va) < len(vb): // a has fewer digits than b
 		return -1
-	} else if len(aNums) > len(bNums) {
+	case len(va) > len(vb): // a has more digits than b
 		return 1
+	case rca == rcb: // length is equal and rcs are equal
+		return 0
+	case rca == 0: // a is a full release
+		return 1
+	case rcb == 0: // b is a full release
+		return -1
+	case rca > rcb:
+		return 1
+	case rca < rcb:
+		return -1
 	}
-	// strings are identical
+
 	return 0
 }

--- a/build/version_test.go
+++ b/build/version_test.go
@@ -17,6 +17,20 @@ func TestVersionCmp(t *testing.T) {
 		{"0.1", "0.1.0", -1},
 		{"0.1", "1.1", -1},
 		{"0.1.1.0", "0.1.1", 1},
+		{"2.3.7", "2.3.7-rc1", 1},
+		{"2.3.7-rc2", "2.3.7", -1},
+		{"1.1.0-rc2", "1.1.0-rc1", 1},
+		{"1.1.0-rc1", "1.1.0-rc2", -1},
+		{"2.5.5", "2.5.4-rc1", 1},
+		{"2.5.4-rc1", "2.5.5", -1},
+		{"2.5.4-rc1", "2.5.4-rc1", 0},
+		{"2.5.4.0-rc1", "2.5.4-rc1", 1},
+		{"2.5.4-rc1", "2.5.4.0-rc1", -1},
+		// version strings are unvalidated
+		{"x.y.z", "2.5.4", -1},
+		{"1.0.0", "x.y.z-rc1", 1},
+		{"0.0.0-rc1", "x.y.z-rc1", 0},
+		{"rc0", "rc1", 0},
 	}
 
 	for _, test := range versionTests {
@@ -35,6 +49,7 @@ func TestIsVersion(t *testing.T) {
 		{"1.0", true},
 		{"1", true},
 		{"0.1.2.3.4.5", true},
+		{"2.5.4", true},
 
 		{"foo", false},
 		{".1", false},
@@ -43,6 +58,9 @@ func TestIsVersion(t *testing.T) {
 		{"1.o", false},
 		{".", false},
 		{"", false},
+		{"-rc1", false},
+		{"2.5.6-rc1", false},
+		{"2.5.6-rc1-rc1", false},
 	}
 
 	for _, test := range versionTests {

--- a/cmd/siac/daemoncmd.go
+++ b/cmd/siac/daemoncmd.go
@@ -178,11 +178,7 @@ func profilestopcmd() {
 // version prints the version of siac and siad.
 func versioncmd() {
 	fmt.Println("Sia Client")
-	if build.ReleaseTag == "" {
-		fmt.Println("\tVersion " + build.NodeVersion)
-	} else {
-		fmt.Println("\tVersion " + build.NodeVersion + "-" + build.ReleaseTag)
-	}
+	fmt.Println("\tVersion " + build.NodeVersion)
 	if build.GitRevision != "" {
 		fmt.Println("\tGit Revision " + build.GitRevision)
 		fmt.Println("\tBuild Time   " + build.BuildTime)

--- a/cmd/siad/main.go
+++ b/cmd/siad/main.go
@@ -65,19 +65,15 @@ func die(args ...interface{}) {
 
 // versionCmd is a cobra command that prints the version of siad.
 func versionCmd(*cobra.Command, []string) {
-	version := build.NodeVersion
-	if build.ReleaseTag != "" {
-		version += "-" + build.ReleaseTag
-	}
 	switch build.Release {
 	case "dev":
-		fmt.Println("siad v" + version + "-dev")
+		fmt.Println("siad v" + build.NodeVersion + "-dev")
 	case "standard":
-		fmt.Println("siad v" + version)
+		fmt.Println("siad v" + build.NodeVersion)
 	case "testing":
-		fmt.Println("siad v" + version + "-testing")
+		fmt.Println("siad v" + build.NodeVersion + "-testing")
 	default:
-		fmt.Println("siad v" + version + "-???")
+		fmt.Println("siad v" + build.NodeVersion + "-???")
 	}
 }
 

--- a/node/api/daemon.go
+++ b/node/api/daemon.go
@@ -481,11 +481,7 @@ func (api *API) daemonStopProfileHandlerPOST(w http.ResponseWriter, _ *http.Requ
 
 // daemonVersionHandler handles the API call that requests the daemon's version.
 func (api *API) daemonVersionHandler(w http.ResponseWriter, _ *http.Request, _ httprouter.Params) {
-	version := build.NodeVersion
-	if build.ReleaseTag != "" {
-		version += "-" + build.ReleaseTag
-	}
-	WriteJSON(w, DaemonVersion{Version: version, GitRevision: build.GitRevision, BuildTime: build.BuildTime})
+	WriteJSON(w, DaemonVersion{Version: build.NodeVersion, GitRevision: build.GitRevision, BuildTime: build.BuildTime})
 }
 
 // daemonStopHandler handles the API call to stop the daemon cleanly.


### PR DESCRIPTION
Changes the `release-scripts/release.sh` to use the makefile instead of having to update `build.NodeVersion` in multiple places. Also removes `build.ReleaseTag` since it seems unnecessary.