### PR TITLE
Fixes build-in-docker.sh

### DIFF
--- a/release-scripts/Dockerfile
+++ b/release-scripts/Dockerfile
@@ -1,14 +1,15 @@
-FROM golang@sha256:1e9c36b3fd7d7f9ab95835fb1ed898293ec0917e44c7e7d2766b4a2d9aa43da6
-# golang:1.14.4-buster
+FROM golang@sha256:0bf61ce389ea41b61ea9f2b2c8eb15824838782df0c9c302dc284f0d6792caf9
+# golang:1.16.7-buster
 
 ARG branch
 ARG version
 
 RUN useradd -ms /bin/bash builder
+RUN chown -R builder:builder /home/builder
 USER builder
 WORKDIR /home/builder
 
-RUN git clone https://github.com/SiaFoundation/siad
+RUN git clone https://github.com/SiaFoundation/siad /home/builder/Sia
 WORKDIR /home/builder/Sia
 RUN git fetch --all && git checkout $branch
 

--- a/release-scripts/release.sh
+++ b/release-scripts/release.sh
@@ -9,23 +9,17 @@ if [[ -z $version ]]; then
 	exit 1
 fi
 
-# get the current directory to preserve paths.
-dir=$(pwd)/release
-# go up one directory to the makefile.
-cd ..
-
 function build {
   os=$1
   arch=$2
 
 	echo Building ${os}...
 	# create workspace
-	folder=$dir/Sia-$version-$os-$arch
+	folder=release/Sia-$version-$os-$arch
 	rm -rf $folder
 	mkdir -p $folder
 
 	GOOS=$1 GOARCH=$2 make static
-	mv release/* $folder
 
 	# compile and hash binaries
 	for pkg in siac siad; do
@@ -34,16 +28,15 @@ function build {
 			bin=${pkg}.exe
 		fi
 
+		mv release/$bin $folder
+
 		(
-			cd $dir
-			sha256sum Sia-$version-$os-$arch/$bin >> $dir/Sia-$version-SHA256SUMS.txt
+			cd release/
+			sha256sum Sia-$version-$os-$arch/$bin >> Sia-$version-SHA256SUMS.txt
 		)
   	done
 
 	cp -r doc LICENSE README.md $folder
-
-	# delete the top-level release folder from the makefile.
-	rm -rf release
 }
 
 # Build amd64 binaries.


### PR DESCRIPTION
+ Fixes the git clone command in the dockerfile
+ Updates the Docker base image to Go v1.16.7
+ Removes the directory preserving lines from release.sh