### PR TITLE
Sector removal progress

### DIFF
--- a/modules/host/storageobligations.go
+++ b/modules/host/storageobligations.go
@@ -987,9 +987,9 @@ func (h *Host) removeStorageObligation(so storageObligation, sos storageObligati
 	// Error is not checked, we want to call remove on every sector even if
 	// there are problems - disk health information will be updated.
 	start := time.Now()
-	h.log.Printf("Removing %v sectors for contract %v.\n", len(so.SectorRoots), so.id())
+	h.log.Printf("Removing %v sectors for contract %v", len(so.SectorRoots), so.id())
 	_ = h.RemoveSectorBatch(so.SectorRoots)
-	h.log.Printf("Removing %v sectors for contract %v finished in %v.\n", len(so.SectorRoots), so.id(),
+	h.log.Printf("Removing %v sectors for contract %v finished in %v", len(so.SectorRoots), so.id(),
 		time.Since(start))
 
 	// Update the host revenue metrics based on the status of the obligation.


### PR DESCRIPTION
When many sectors are being removed, siad does not respond to any requests. This change is to help users monitor progress of removal while siad is not responding by monitoring host.log and alerts.

Added logging of progress when removing sectors.
Number of sectors to be removed is printed in the host log.
Alert is registered showing removal progress.
