### PR TITLE
Introduce sectorMu in Host to reduce download latency

### DIFF
--- a/modules/host/contractmanager/persist_test.go
+++ b/modules/host/contractmanager/persist_test.go
@@ -546,11 +546,11 @@ func TestLoadMissingStorageFolder(t *testing.T) {
 		t.Error("folder should be visible again")
 	}
 	if sfOne.Capacity != sfOne.CapacityRemaining+modules.SectorSize {
-		cmt.cm.wal.mu.Lock()
+		cmt.cm.sectorMu.Lock()
 		t.Log("Usage len:", len(cmt.cm.storageFolders[sfOne.Index].usage))
 		t.Log("Reported Sectors:", cmt.cm.storageFolders[sfOne.Index].sectors)
 		t.Log("Avail:", len(cmt.cm.storageFolders[sfOne.Index].availableSectors))
-		cmt.cm.wal.mu.Unlock()
+		cmt.cm.sectorMu.Unlock()
 		t.Error("One sector's worth of capacity should be consumed:", sfOne.Capacity, sfOne.CapacityRemaining)
 	}
 

--- a/modules/host/contractmanager/storagefoldershrink.go
+++ b/modules/host/contractmanager/storagefoldershrink.go
@@ -18,6 +18,8 @@ type (
 // commitStorageFolderReduction commits a storage folder reduction to the state
 // and filesystem.
 func (wal *writeAheadLog) commitStorageFolderReduction(sfr storageFolderReduction) {
+	wal.cm.sectorMu.Lock()
+	defer wal.cm.sectorMu.Unlock()
 	sf, exists := wal.cm.storageFolders[sfr.Index]
 	if !exists {
 		wal.cm.log.Critical("ERROR: storage folder reduction established for a storage folder that does not exist")
@@ -55,9 +57,9 @@ func (wal *writeAheadLog) commitStorageFolderReduction(sfr storageFolderReductio
 // sectors in the truncated space to new storage folders.
 func (wal *writeAheadLog) shrinkStorageFolder(index uint16, newSectorCount uint32, force bool) error {
 	// Retrieve the specified storage folder.
-	wal.mu.Lock()
+	wal.cm.sectorMu.Lock()
 	sf, exists := wal.cm.storageFolders[index]
-	wal.mu.Unlock()
+	wal.cm.sectorMu.Unlock()
 	if !exists {
 		return errStorageFolderNotFound
 	}

--- a/modules/host/contractmanager/writeaheadlogsync.go
+++ b/modules/host/contractmanager/writeaheadlogsync.go
@@ -57,7 +57,13 @@ func (wal *writeAheadLog) syncResources() {
 	}()
 
 	// Sync all of the storage folders.
+	wal.cm.sectorMu.Lock()
+	sfs := make([]*storageFolder, 0, len(wal.cm.storageFolders))
 	for _, sf := range wal.cm.storageFolders {
+		sfs = append(sfs, sf)
+	}
+	wal.cm.sectorMu.Unlock()
+	for _, sf := range sfs {
 		// Skip operation on unavailable storage folders.
 		if atomic.LoadUint64(&sf.atomicUnavailable) == 1 {
 			continue


### PR DESCRIPTION
This PR introduces a new mutex in the contract manager. The mutex itself comes with a description in the docstring but I'll summarize it here as well.

The host syncs all of its persistence to disk every 500ms. It does so while holding the wallet mutex. That same mutex is required to read sector locations, storage folders and lock storage locations in memory.

That's an issue because the persistence can take hundreds of milliseconds or as I noticed while running a local test even a few seconds. That was on an SSD. I assume most hosts have HDDs which take even longer.

So when a user downloads a sector, they have to acquire that lock to locate the sector which potentially slows down the TTFB by a lot.

This is why I added a dedicated log for the fields required for downloads which consistently reduces the lookup time to <1ms times since they no longer require waiting for syncing data to disk.


NOTE: I understand that the host is a gentle creature and the locking in the host is pretty magical so I went for this rather hacky but not very invasive solution. Tbh the host deserves a full overhaul but I don't think anybody got the capacity for that at the moment.