### PR TITLE
gateway: Remove useUPNP flag from New

### DIFF
--- a/cmd/sia-node-scanner/main.go
+++ b/cmd/sia-node-scanner/main.go
@@ -194,7 +194,7 @@ func newNodeScanner(scannerDirPrefix string) (ns *nodeScanner) {
 	// Create dummy gateway at localhost. It is used only to connect/disconnect
 	// from nodes and to use the ShareNodes RPC with other nodes for the purposes
 	// of this scan.
-	g, err := gateway.New("localhost:0", true, true, scannerGatewayDirPath)
+	g, err := gateway.New("localhost:0", true, scannerGatewayDirPath)
 	if err != nil {
 		log.Fatal("Error making new gateway: ", err)
 	}

--- a/cmd/sia-node-scanner/scanner_test.go
+++ b/cmd/sia-node-scanner/scanner_test.go
@@ -81,7 +81,7 @@ func TestSendShareNodesRequests(t *testing.T) {
 	}
 	t.Parallel()
 
-	mainGateway, err := gateway.New("localhost:0", true, false, build.TempDir("TestSendShareNodesRequests"))
+	mainGateway, err := gateway.New("localhost:0", true, build.TempDir("TestSendShareNodesRequests"))
 	if err != nil {
 		t.Fatal("Error making new gateway: ", err)
 	}
@@ -94,7 +94,7 @@ func TestSendShareNodesRequests(t *testing.T) {
 	// Create testing gateways.
 	gateways := make([]*gateway.Gateway, 0, numTestingGateways)
 	for i := 0; i < numTestingGateways; i++ {
-		g, err := gateway.New("localhost:0", true, false, build.TempDir(fmt.Sprintf("TestSendShareNodesRequests-%d", i)))
+		g, err := gateway.New("localhost:0", true, build.TempDir(fmt.Sprintf("TestSendShareNodesRequests-%d", i)))
 		if err != nil {
 			t.Fatal("Error making new gateway: ", err)
 		}
@@ -157,7 +157,7 @@ func TestRestartScanner(t *testing.T) {
 	gateways := make([]*gateway.Gateway, 0, numTestingGateways)
 	gatewayAddrs := make([]modules.NetAddress, 0, numTestingGateways)
 	for i := 0; i < numTestingGateways; i++ {
-		g, err := gateway.New(fmt.Sprintf("localhost:4444%d", i), true, false, build.TempDir(fmt.Sprintf("SiaNodeScannerTestGateway-%d", i)))
+		g, err := gateway.New(fmt.Sprintf("localhost:4444%d", i), true, build.TempDir(fmt.Sprintf("SiaNodeScannerTestGateway-%d", i)))
 		if err != nil {
 			t.Fatal("Error making new gateway: ", err)
 		}

--- a/modules/consensus/accept_bench_test.go
+++ b/modules/consensus/accept_bench_test.go
@@ -29,7 +29,7 @@ func BenchmarkAcceptEmptyBlocks(b *testing.B) {
 	// Create an alternate testing consensus set, which does not
 	// have any subscribers
 	testdir := build.TempDir(modules.ConsensusDir, "BenchmarkEmptyBlocks - 2")
-	g, err := gateway.New("localhost:0", false, false, filepath.Join(testdir, modules.GatewayDir))
+	g, err := gateway.New("localhost:0", false, filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -109,7 +109,7 @@ func BenchmarkAcceptSmallBlocks(b *testing.B) {
 	// Create an alternate testing consensus set, which does not
 	// have any subscribers
 	testdir := build.TempDir(modules.ConsensusDir, "BenchmarkAcceptSmallBlocks - 2")
-	g, err := gateway.New("localhost:0", false, false, filepath.Join(testdir, modules.GatewayDir))
+	g, err := gateway.New("localhost:0", false, filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/modules/consensus/consensusset_test.go
+++ b/modules/consensus/consensusset_test.go
@@ -97,7 +97,7 @@ func blankConsensusSetTester(name string, deps modules.Dependencies) (*consensus
 	testdir := build.TempDir(modules.ConsensusDir, name)
 
 	// Create modules.
-	g, err := gateway.New("localhost:0", false, false, filepath.Join(testdir, modules.GatewayDir))
+	g, err := gateway.New("localhost:0", false, filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		return nil, err
 	}
@@ -191,7 +191,7 @@ func TestDatabaseClosing(t *testing.T) {
 	testdir := build.TempDir(modules.ConsensusDir, t.Name())
 
 	// Create the gateway.
-	g, err := gateway.New("localhost:0", false, false, filepath.Join(testdir, modules.GatewayDir))
+	g, err := gateway.New("localhost:0", false, filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/consensus/persist_test.go
+++ b/modules/consensus/persist_test.go
@@ -31,7 +31,7 @@ func TestSaveLoad(t *testing.T) {
 
 	// Reassigning this will lose subscribers and such, but we
 	// just want to call load and get a hash
-	g, err := gateway.New("localhost:0", false, false, build.TempDir(modules.ConsensusDir, t.Name(), modules.GatewayDir))
+	g, err := gateway.New("localhost:0", false, build.TempDir(modules.ConsensusDir, t.Name(), modules.GatewayDir))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/consensus/processedblock_test.go
+++ b/modules/consensus/processedblock_test.go
@@ -24,7 +24,7 @@ func TestIntegrationMinimumValidChildTimestamp(t *testing.T) {
 
 	// Create a custom consensus set to control the blocks.
 	testdir := build.TempDir(modules.ConsensusDir, t.Name())
-	g, err := gateway.New("localhost:0", false, false, filepath.Join(testdir, modules.GatewayDir))
+	g, err := gateway.New("localhost:0", false, filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/consensus/synchronize_ibd_test.go
+++ b/modules/consensus/synchronize_ibd_test.go
@@ -225,7 +225,7 @@ func TestInitialBlockchainDownloadDisconnects(t *testing.T) {
 	}
 
 	testdir := build.TempDir(modules.ConsensusDir, t.Name())
-	g, err := gateway.New("localhost:0", false, false, filepath.Join(testdir, "local", modules.GatewayDir))
+	g, err := gateway.New("localhost:0", false, filepath.Join(testdir, "local", modules.GatewayDir))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -263,7 +263,7 @@ func TestInitialBlockchainDownloadDisconnects(t *testing.T) {
 		nil, nil, nil, nil, nil,
 	}
 	for i, rpcErr := range rpcErrs {
-		g, err := gateway.New("localhost:0", false, false, filepath.Join(testdir, "remote - "+strconv.Itoa(i), modules.GatewayDir))
+		g, err := gateway.New("localhost:0", false, filepath.Join(testdir, "remote - "+strconv.Itoa(i), modules.GatewayDir))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -311,7 +311,7 @@ func TestInitialBlockchainDownloadDoneRules(t *testing.T) {
 
 	// Create a gateway that can be forced to return errors when its RPC method
 	// is called, then create a consensus set using that gateway.
-	g, err := gateway.New("localhost:0", false, false, filepath.Join(testdir, "local", modules.GatewayDir))
+	g, err := gateway.New("localhost:0", false, filepath.Join(testdir, "local", modules.GatewayDir))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -392,7 +392,7 @@ func TestInitialBlockchainDownloadDoneRules(t *testing.T) {
 		cs.managedInitialBlockchainDownload()
 		doneChan <- struct{}{}
 	}()
-	gatewayTimesout, err := gateway.New("localhost:0", false, false, filepath.Join(testdir, "remote - timesout", modules.GatewayDir))
+	gatewayTimesout, err := gateway.New("localhost:0", false, filepath.Join(testdir, "remote - timesout", modules.GatewayDir))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -420,7 +420,7 @@ func TestInitialBlockchainDownloadDoneRules(t *testing.T) {
 	// Add a peer that is synced to the peer that is not synced. IBD should not
 	// be considered completed when there is a tie between synced and
 	// not-synced peers.
-	gatewayNoTimeout, err := gateway.New("localhost:0", false, false, filepath.Join(testdir, "remote - no timeout1", modules.GatewayDir))
+	gatewayNoTimeout, err := gateway.New("localhost:0", false, filepath.Join(testdir, "remote - no timeout1", modules.GatewayDir))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -445,7 +445,7 @@ func TestInitialBlockchainDownloadDoneRules(t *testing.T) {
 	// Test when there is 2 peers that are synced and one that is not synced.
 	// There is now a majority synced peers and the minIBDWaitTime has passed,
 	// so the IBD function should finish.
-	gatewayNoTimeout2, err := gateway.New("localhost:0", false, false, filepath.Join(testdir, "remote - no timeout2", modules.GatewayDir))
+	gatewayNoTimeout2, err := gateway.New("localhost:0", false, filepath.Join(testdir, "remote - no timeout2", modules.GatewayDir))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -470,7 +470,7 @@ func TestInitialBlockchainDownloadDoneRules(t *testing.T) {
 	// Test when there are >= minNumOutbound peers and >= minNumOutbound peers are synced.
 	gatewayNoTimeouts := make([]modules.Gateway, minNumOutbound-1)
 	for i := 0; i < len(gatewayNoTimeouts); i++ {
-		tmpG, err := gateway.New("localhost:0", false, false, filepath.Join(testdir, fmt.Sprintf("remote - no timeout-auto-%v", i+3), modules.GatewayDir))
+		tmpG, err := gateway.New("localhost:0", false, filepath.Join(testdir, fmt.Sprintf("remote - no timeout-auto-%v", i+3), modules.GatewayDir))
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/modules/consensus/synchronize_test.go
+++ b/modules/consensus/synchronize_test.go
@@ -571,7 +571,7 @@ func TestRPCSendBlockSendsOnlyNecessaryBlocks(t *testing.T) {
 	// can connect it to the remote peer before calling consensus.New so as to
 	// prevent SendBlocks from triggering on Connect.
 	testdir := build.TempDir(modules.ConsensusDir, t.Name()+" - local")
-	g, err := gateway.New("localhost:0", false, false, filepath.Join(testdir, modules.GatewayDir))
+	g, err := gateway.New("localhost:0", false, filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/explorer/explorer_test.go
+++ b/modules/explorer/explorer_test.go
@@ -38,7 +38,7 @@ func createExplorerTester(name string) (*explorerTester, error) {
 
 	// Create and assemble the dependencies.
 	testdir := build.TempDir(modules.ExplorerDir, name)
-	g, err := gateway.New("localhost:0", false, false, filepath.Join(testdir, modules.GatewayDir))
+	g, err := gateway.New("localhost:0", false, filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		return nil, err
 	}
@@ -111,7 +111,7 @@ func TestExplorerGenesisHeight(t *testing.T) {
 	}
 	// Create the dependencies.
 	testdir := build.TempDir(modules.HostDir, t.Name())
-	g, err := gateway.New("localhost:0", false, false, filepath.Join(testdir, modules.GatewayDir))
+	g, err := gateway.New("localhost:0", false, filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/gateway/gateway.go
+++ b/modules/gateway/gateway.go
@@ -360,8 +360,8 @@ func (g *Gateway) SetRateLimits(downloadSpeed, uploadSpeed int64) error {
 }
 
 // New returns an initialized Gateway.
-func New(addr string, bootstrap bool, useUPNP bool, persistDir string) (*Gateway, error) {
-	return NewCustomGateway(addr, bootstrap, useUPNP, persistDir, modules.ProdDependencies)
+func New(addr string, bootstrap bool, persistDir string) (*Gateway, error) {
+	return NewCustomGateway(addr, bootstrap, true, persistDir, modules.ProdDependencies)
 }
 
 // NewCustomGateway returns an initialized Gateway with custom dependencies.

--- a/modules/gateway/gateway_test.go
+++ b/modules/gateway/gateway_test.go
@@ -24,7 +24,7 @@ func newTestingGateway(t *testing.T) *Gateway {
 		panic("newTestingGateway called during short test")
 	}
 
-	g, err := New("localhost:0", false, false, build.TempDir("gateway", t.Name()))
+	g, err := New("localhost:0", false, build.TempDir("gateway", t.Name()))
 	if err != nil {
 		panic(err)
 	}
@@ -38,7 +38,7 @@ func newNamedTestingGateway(t *testing.T, suffix string) *Gateway {
 		panic("newTestingGateway called during short test")
 	}
 
-	g, err := New("localhost:0", false, false, build.TempDir("gateway", t.Name()+suffix))
+	g, err := New("localhost:0", false, build.TempDir("gateway", t.Name()+suffix))
 	if err != nil {
 		panic(err)
 	}
@@ -161,13 +161,13 @@ func TestNew(t *testing.T) {
 	}
 	t.Parallel()
 
-	if _, err := New("", false, false, ""); err == nil {
+	if _, err := New("", false, ""); err == nil {
 		t.Fatal("expecting persistDir error, got nil")
 	}
-	if _, err := New("localhost:0", false, false, ""); err == nil {
+	if _, err := New("localhost:0", false, ""); err == nil {
 		t.Fatal("expecting persistDir error, got nil")
 	}
-	if g, err := New("foo", false, false, build.TempDir("gateway", t.Name()+"1")); err == nil {
+	if g, err := New("foo", false, build.TempDir("gateway", t.Name()+"1")); err == nil {
 		t.Fatal("expecting listener error, got nil", g.myAddr)
 	}
 	// create corrupted nodes.json
@@ -177,7 +177,7 @@ func TestNew(t *testing.T) {
 	if err != nil {
 		t.Fatal("couldn't create corrupted file:", err)
 	}
-	if _, err := New("localhost:0", false, false, dir); err == nil {
+	if _, err := New("localhost:0", false, dir); err == nil {
 		t.Fatal("expected load error, got nil")
 	}
 }
@@ -343,7 +343,7 @@ func TestManualConnectDisconnectPersist(t *testing.T) {
 
 	// Restart g2 without deleting the tmp dir
 	g2.Close()
-	g2, err := New("localhost:0", false, false, g2.persistDir)
+	g2, err := New("localhost:0", false, g2.persistDir)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/gateway/peers_test.go
+++ b/modules/gateway/peers_test.go
@@ -1206,7 +1206,7 @@ func TestPeerManagerPriority(t *testing.T) {
 
 	// Restart g1. It should immediately reconnect to g2, and then g3 after a
 	// delay.
-	g1, err = New(string(g1.myAddr), false, false, g1.persistDir)
+	g1, err = New(string(g1.myAddr), false, g1.persistDir)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/gateway/persist_test.go
+++ b/modules/gateway/persist_test.go
@@ -36,7 +36,7 @@ func TestLoad(t *testing.T) {
 	g.Close()
 
 	// Start second gateway
-	g2, err := New("localhost:0", false, false, g.persistDir)
+	g2, err := New("localhost:0", false, g.persistDir)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/host/host_test.go
+++ b/modules/host/host_test.go
@@ -142,7 +142,7 @@ func blankMockHostTester(d modules.Dependencies, name string) (*hostTester, erro
 	}
 
 	// Create the modules.
-	g, err := gateway.New("localhost:0", false, false, filepath.Join(testdir, modules.GatewayDir))
+	g, err := gateway.New("localhost:0", false, filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		return nil, err
 	}

--- a/modules/host/persist_compat_1.2.0_test.go
+++ b/modules/host/persist_compat_1.2.0_test.go
@@ -32,7 +32,7 @@ func loadExistingHostWithNewDeps(modulesDir, siaMuxDir, hostDir string) (closeFn
 	}
 
 	// Create the host dependencies.
-	g, err := gateway.New("localhost:0", false, false, filepath.Join(modulesDir, modules.GatewayDir))
+	g, err := gateway.New("localhost:0", false, filepath.Join(modulesDir, modules.GatewayDir))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/modules/host/storageobligations_smoke_test.go
+++ b/modules/host/storageobligations_smoke_test.go
@@ -31,7 +31,7 @@ import (
 func newTestTPool(name string, deps modules.Dependencies) (func() error, *transactionpool.TransactionPool, error) {
 	testdir := build.TempDir(modules.HostDir, name)
 	// Create the modules needed.
-	g, err := gateway.New("localhost:0", false, false, filepath.Join(testdir, modules.GatewayDir))
+	g, err := gateway.New("localhost:0", false, filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/modules/miner/miner_test.go
+++ b/modules/miner/miner_test.go
@@ -37,7 +37,7 @@ func createMinerTester(name string) (*minerTester, error) {
 	testdir := build.TempDir(modules.MinerDir, name)
 
 	// Create the modules.
-	g, err := gateway.New("localhost:0", false, false, filepath.Join(testdir, modules.GatewayDir))
+	g, err := gateway.New("localhost:0", false, filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		return nil, err
 	}

--- a/modules/renter/contractor/contractor_test.go
+++ b/modules/renter/contractor/contractor_test.go
@@ -40,7 +40,7 @@ func tryClose(cf closeFn, t *testing.T) {
 
 // newModules initializes the modules needed to test creating a new contractor
 func newModules(testdir string) (modules.ConsensusSet, modules.Wallet, modules.TransactionPool, *siamux.SiaMux, modules.HostDB, closeFn, error) {
-	g, err := gateway.New("localhost:0", false, false, filepath.Join(testdir, modules.GatewayDir))
+	g, err := gateway.New("localhost:0", false, filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		return nil, nil, nil, nil, nil, nil, err
 	}

--- a/modules/renter/contractor/host_integration_test.go
+++ b/modules/renter/contractor/host_integration_test.go
@@ -71,7 +71,7 @@ func newTestingWallet(testdir string, cs modules.ConsensusSet, tp modules.Transa
 
 // newCustomTestingHost is a helper function that creates a ready-to-use host.
 func newCustomTestingHost(testdir string, cs modules.ConsensusSet, tp modules.TransactionPool, mux *siamux.SiaMux, deps modules.Dependencies) (modules.Host, closeFn, error) {
-	g, err := gateway.New("localhost:0", false, false, filepath.Join(testdir, modules.GatewayDir))
+	g, err := gateway.New("localhost:0", false, filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -168,7 +168,7 @@ func newCustomTestingTrio(name string, mux *siamux.SiaMux, hdeps, cdeps modules.
 	testdir := build.TempDir("contractor", name)
 
 	// create miner
-	g, err := gateway.New("localhost:0", false, false, filepath.Join(testdir, modules.GatewayDir))
+	g, err := gateway.New("localhost:0", false, filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}

--- a/modules/renter/contractor/negotiate_test.go
+++ b/modules/renter/contractor/negotiate_test.go
@@ -48,7 +48,7 @@ func (rt *contractorTester) Close() error {
 func newContractorTester(name string) (*contractorTester, closeFn, error) {
 	// Create the modules.
 	testdir := build.TempDir("contractor", name)
-	g, err := gateway.New("localhost:0", false, false, filepath.Join(testdir, modules.GatewayDir))
+	g, err := gateway.New("localhost:0", false, filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/modules/renter/hostdb/hostdb_test.go
+++ b/modules/renter/hostdb/hostdb_test.go
@@ -85,7 +85,7 @@ func newHDBTesterDeps(name string, deps modules.Dependencies) (*hdbTester, error
 	}
 	testDir := build.TempDir("HostDB", name)
 
-	g, err := gateway.New("localhost:0", false, false, filepath.Join(testDir, modules.GatewayDir))
+	g, err := gateway.New("localhost:0", false, filepath.Join(testDir, modules.GatewayDir))
 	if err != nil {
 		return nil, err
 	}
@@ -156,7 +156,7 @@ func TestNew(t *testing.T) {
 	}
 	t.Parallel()
 	testDir := build.TempDir("HostDB", t.Name())
-	g, err := gateway.New("localhost:0", false, false, filepath.Join(testDir, modules.GatewayDir))
+	g, err := gateway.New("localhost:0", false, filepath.Join(testDir, modules.GatewayDir))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/renter/renter_test.go
+++ b/modules/renter/renter_test.go
@@ -208,7 +208,7 @@ func newRenterTesterNoRenter(testdir string) (*renterTester, error) {
 	}
 
 	// Create the modules.
-	g, err := gateway.New("localhost:0", false, false, filepath.Join(testdir, modules.GatewayDir))
+	g, err := gateway.New("localhost:0", false, filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		return nil, err
 	}

--- a/modules/transactionpool/transactionpool_test.go
+++ b/modules/transactionpool/transactionpool_test.go
@@ -35,7 +35,7 @@ type tpoolTester struct {
 func blankTpoolTester(name string) (*tpoolTester, error) {
 	// Initialize the modules.
 	testdir := build.TempDir(modules.TransactionPoolDir, name)
-	g, err := gateway.New("localhost:0", false, false, filepath.Join(testdir, modules.GatewayDir))
+	g, err := gateway.New("localhost:0", false, filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		return nil, err
 	}
@@ -138,7 +138,7 @@ func TestIntegrationNewNilInputs(t *testing.T) {
 	}
 	// Create a gateway and consensus set.
 	testdir := build.TempDir(modules.TransactionPoolDir, t.Name())
-	g, err := gateway.New("localhost:0", false, false, filepath.Join(testdir, modules.GatewayDir))
+	g, err := gateway.New("localhost:0", false, filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/wallet/wallet_test.go
+++ b/modules/wallet/wallet_test.go
@@ -34,7 +34,7 @@ type walletTester struct {
 func createWalletTester(name string, deps modules.Dependencies) (*walletTester, error) {
 	// Create the modules
 	testdir := build.TempDir(modules.WalletDir, name)
-	g, err := gateway.New("localhost:0", false, false, filepath.Join(testdir, modules.GatewayDir))
+	g, err := gateway.New("localhost:0", false, filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		return nil, err
 	}
@@ -93,7 +93,7 @@ func createWalletTester(name string, deps modules.Dependencies) (*walletTester, 
 func createBlankWalletTester(name string) (*walletTester, error) {
 	// Create the modules
 	testdir := build.TempDir(modules.WalletDir, name)
-	g, err := gateway.New("localhost:0", false, false, filepath.Join(testdir, modules.GatewayDir))
+	g, err := gateway.New("localhost:0", false, filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		return nil, err
 	}
@@ -145,7 +145,7 @@ func TestNilInputs(t *testing.T) {
 		t.SkipNow()
 	}
 	testdir := build.TempDir(modules.WalletDir, t.Name())
-	g, err := gateway.New("localhost:0", false, false, filepath.Join(testdir, modules.GatewayDir))
+	g, err := gateway.New("localhost:0", false, filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -212,7 +212,7 @@ func TestCloseWallet(t *testing.T) {
 		t.Skip()
 	}
 	testdir := build.TempDir(modules.WalletDir, t.Name())
-	g, err := gateway.New("localhost:0", false, false, filepath.Join(testdir, modules.GatewayDir))
+	g, err := gateway.New("localhost:0", false, filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/node/api/gateway_test.go
+++ b/node/api/gateway_test.go
@@ -43,7 +43,7 @@ func TestGatewayPeerConnect(t *testing.T) {
 	}
 	defer st.server.panicClose()
 
-	peer, err := gateway.New("localhost:0", false, false, build.TempDir("api", t.Name()+"2", "gateway"))
+	peer, err := gateway.New("localhost:0", false, build.TempDir("api", t.Name()+"2", "gateway"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -81,7 +81,7 @@ func TestGatewayPeerDisconnect(t *testing.T) {
 	}
 	defer st.server.panicClose()
 
-	peer, err := gateway.New("localhost:0", false, false, build.TempDir("api", t.Name()+"2", "gateway"))
+	peer, err := gateway.New("localhost:0", false, build.TempDir("api", t.Name()+"2", "gateway"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/node/api/hostdb_test.go
+++ b/node/api/hostdb_test.go
@@ -277,7 +277,7 @@ func assembleHostPort(key crypto.CipherKey, hostHostname string, testdir string)
 	}
 
 	// Create the modules.
-	g, err := gateway.New("localhost:0", false, false, filepath.Join(testdir, modules.GatewayDir))
+	g, err := gateway.New("localhost:0", false, filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		return nil, err
 	}

--- a/node/api/server_helpers_test.go
+++ b/node/api/server_helpers_test.go
@@ -292,7 +292,7 @@ func assembleAuthenticatedServerTester(requiredPassword string, key crypto.Ciphe
 	}
 
 	// Create the modules.
-	g, err := gateway.New("localhost:0", false, false, filepath.Join(testdir, modules.GatewayDir))
+	g, err := gateway.New("localhost:0", false, filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		return nil, err
 	}
@@ -377,7 +377,7 @@ func assembleExplorerServerTester(testdir string) (*serverTester, error) {
 	}
 
 	// Create the modules.
-	g, err := gateway.New("localhost:0", false, false, filepath.Join(testdir, modules.GatewayDir))
+	g, err := gateway.New("localhost:0", false, filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		return nil, err
 	}

--- a/node/api/wallet_test.go
+++ b/node/api/wallet_test.go
@@ -33,7 +33,7 @@ func TestWalletGETEncrypted(t *testing.T) {
 	t.Parallel()
 	// Check a wallet that has never been encrypted.
 	testdir := build.TempDir("api", t.Name())
-	g, err := gateway.New("localhost:0", false, false, filepath.Join(testdir, modules.GatewayDir))
+	g, err := gateway.New("localhost:0", false, filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		t.Fatal("Failed to create gateway:", err)
 	}
@@ -172,7 +172,7 @@ func TestWalletBlankEncrypt(t *testing.T) {
 	t.Parallel()
 	// Create a server object without encrypting or unlocking the wallet.
 	testdir := build.TempDir("api", t.Name())
-	g, err := gateway.New("localhost:0", false, false, filepath.Join(testdir, modules.GatewayDir))
+	g, err := gateway.New("localhost:0", false, filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -240,7 +240,7 @@ func TestIntegrationWalletInitSeed(t *testing.T) {
 	}
 	// Create a server object without encrypting or unlocking the wallet.
 	testdir := build.TempDir("api", "TestIntegrationWalletInitSeed")
-	g, err := gateway.New("localhost:0", false, false, filepath.Join(testdir, modules.GatewayDir))
+	g, err := gateway.New("localhost:0", false, filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
https://github.com/SiaFoundation/siad/pull/44 changed the `gateway.New` constructor, breaking compatibility. This was unnecessary: we only needed to change `gateway.NewCustomGateway`.