### PR TITLE
Fix sectorMu deadlocks

### DIFF
--- a/modules/host/contractmanager/persist.go
+++ b/modules/host/contractmanager/persist.go
@@ -162,9 +162,7 @@ func (cm *ContractManager) loadSectorLocations(sf *storageFolder) {
 		}
 
 		// Add the sector to the sector location map.
-		cm.sectorMu.Lock()
 		cm.sectorLocations[id] = sl
-		cm.sectorMu.Unlock()
 		sf.sectors++
 	}
 	atomic.StoreUint64(&sf.atomicUnavailable, 0)


### PR DESCRIPTION
This fixes the two issues I noticed in #50

+ Fixes a deadlock on startup when calling `loadSectorLocations` from `newContractManager`.
+ Fixes a deadlock in `managedLockSector` when waiting to acquire a sector lock.
+ Remove usage of `lockSector` to prevent holding `sectorMu` while potentially waiting on it in `managedUnlockSector`

Closes #52 