### PR TITLE
v2: Add offset and limit to wallet transactions and addresses endpoints

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"time"
 
 	"go.sia.tech/core/types"
 )
@@ -62,14 +63,14 @@ func (c *Client) WalletAddress() (resp WalletAddress, err error) {
 }
 
 // WalletAddresses returns all addresses controlled by the wallet.
-func (c *Client) WalletAddresses() (resp WalletAddresses, err error) {
-	err = c.get("/wallet/addresses", &resp)
+func (c *Client) WalletAddresses(start, end int) (resp WalletAddresses, err error) {
+	err = c.get(fmt.Sprintf("/wallet/addresses?start=%d&end=%d", start, end), &resp)
 	return
 }
 
 // WalletTransactions returns all transactions relevant to the wallet.
-func (c *Client) WalletTransactions() (resp []WalletTransaction, err error) {
-	err = c.get("/wallet/transactions", &resp)
+func (c *Client) WalletTransactions(since time.Time, max int) (resp []WalletTransaction, err error) {
+	err = c.get(fmt.Sprintf("/wallet/transactions?since=%s&max=%d", since.Format(time.RFC3339), max), &resp)
 	return
 }
 

--- a/cmd/siac/main.go
+++ b/cmd/siac/main.go
@@ -4,11 +4,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"math"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"text/tabwriter"
+	"time"
 
 	"go.sia.tech/core/types"
 	"go.sia.tech/siad/v2/api"
@@ -250,7 +252,7 @@ func main() {
 			cmd.Usage()
 			return
 		}
-		addresses, err := getClient().WalletAddresses()
+		addresses, err := getClient().WalletAddresses(0, math.MaxInt64)
 		check("Couldn't get address:", err)
 		for _, address := range addresses {
 			fmt.Println(address)
@@ -274,7 +276,7 @@ func main() {
 			cmd.Usage()
 			return
 		}
-		transactions, err := getClient().WalletTransactions()
+		transactions, err := getClient().WalletTransactions(time.Time{}, 0)
 		check("Couldn't get transactions:", err)
 
 		w := makeTabWriter()

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	"go.sia.tech/core/consensus"
 	"go.sia.tech/core/types"
@@ -75,7 +76,7 @@ type Store interface {
 	AddAddress(addr types.Address, index uint64) error
 	AddressIndex(addr types.Address) (uint64, bool)
 	SpendableSiacoinElements() []types.SiacoinElement
-	Transactions() []Transaction
+	Transactions(since time.Time, max int) []Transaction
 }
 
 // A HotWallet tracks spendable outputs controlled by in-memory keys. It can
@@ -226,17 +227,18 @@ func (w *HotWallet) SignTransaction(vc consensus.ValidationContext, txn *types.T
 // A Transaction is a transaction relevant to the wallet, paired with useful
 // metadata.
 type Transaction struct {
-	Raw     types.Transaction
-	Index   types.ChainIndex
-	ID      types.TransactionID
-	Inflow  types.Currency
-	Outflow types.Currency
+	Raw       types.Transaction
+	Index     types.ChainIndex
+	ID        types.TransactionID
+	Inflow    types.Currency
+	Outflow   types.Currency
+	Timestamp time.Time
 }
 
 // Transactions returns all transactions relevant to the wallet, ordered
 // oldest-to-newest.
-func (w *HotWallet) Transactions() []Transaction {
-	return w.store.Transactions()
+func (w *HotWallet) Transactions(since time.Time, max int) []Transaction {
+	return w.store.Transactions(since, max)
 }
 
 // NewHotWallet returns a hot wallet using the provided Store and seed.


### PR DESCRIPTION
This adds the ability to filter by offset/limit to the wallet transactions and addresses endpoints.  Also performs sanity checks to ensure we do not access out of bounds elements in the slices.