### PR TITLE
v2: Add syncer store interface and ensure syncer has a healthy number of peers

### DIFF
--- a/internal/p2putil/store.go
+++ b/internal/p2putil/store.go
@@ -1,0 +1,100 @@
+package p2putil
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// EphemeralStore implements p2p.SyncerStore in memory.
+type EphemeralStore struct {
+	mu    sync.Mutex
+	peers map[string]struct{}
+}
+
+// AddPeer implements p2p.SyncerStore.
+func (s *EphemeralStore) AddPeer(addr string) error {
+	s.mu.Lock()
+	s.peers[addr] = struct{}{}
+	s.mu.Unlock()
+	return nil
+}
+
+// RandomPeer implements p2p.SyncerStore.
+func (s *EphemeralStore) RandomPeer() (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for peer := range s.peers {
+		return peer, nil
+	}
+	return "", errors.New("no peers in list")
+}
+
+// NewEphemeralStore returns a new EphemeralStore.
+func NewEphemeralStore() *EphemeralStore {
+	return &EphemeralStore{
+		peers: make(map[string]struct{}),
+	}
+}
+
+// JSONStore implements p2p.SyncerStore in memory, backed by a JSON file.
+type JSONStore struct {
+	*EphemeralStore
+	dir string
+}
+
+// AddPeer implements p2p.SyncerStore.
+func (s *JSONStore) AddPeer(addr string) error {
+	s.EphemeralStore.AddPeer(addr)
+	return s.save()
+}
+
+func (s *JSONStore) load() error {
+	dst := filepath.Join(s.dir, "peers.json")
+	f, err := os.Open(dst)
+	if os.IsNotExist(err) {
+		return nil
+	} else if err != nil {
+		return err
+	}
+	defer f.Close()
+	return json.NewDecoder(f).Decode(&s.peers)
+}
+
+func (s *JSONStore) save() error {
+	js, err := json.MarshalIndent(s.peers, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	dst := filepath.Join(s.dir, "peers.json")
+	f, err := os.OpenFile(dst+"_tmp", os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0660)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	if _, err = f.Write(js); err != nil {
+		return err
+	} else if f.Sync(); err != nil {
+		return err
+	} else if f.Close(); err != nil {
+		return err
+	} else if err := os.Rename(dst+"_tmp", dst); err != nil {
+		return err
+	}
+	return nil
+}
+
+// NewJSONStore returns a new JSONStore.
+func NewJSONStore(dir string) (*JSONStore, error) {
+	s := &JSONStore{
+		EphemeralStore: NewEphemeralStore(),
+		dir:            dir,
+	}
+	if err := s.load(); err != nil {
+		return nil, err
+	}
+	return s, nil
+}

--- a/p2p/syncer_test.go
+++ b/p2p/syncer_test.go
@@ -12,6 +12,7 @@ import (
 	"go.sia.tech/core/types"
 	"go.sia.tech/siad/v2/internal/chainutil"
 	"go.sia.tech/siad/v2/internal/cpuminer"
+	"go.sia.tech/siad/v2/internal/p2putil"
 	"go.sia.tech/siad/v2/internal/walletutil"
 	"go.sia.tech/siad/v2/txpool"
 	"go.sia.tech/siad/v2/wallet"
@@ -104,7 +105,7 @@ func newTestNode(tb testing.TB, genesisID types.BlockID, c consensus.Checkpoint)
 	cm.AddSubscriber(ws, cm.Tip())
 	m := cpuminer.New(c.Context, w.NextAddress(), tp)
 	cm.AddSubscriber(m, cm.Tip())
-	s, err := NewSyncer(":0", genesisID, cm, tp)
+	s, err := NewSyncer(":0", genesisID, cm, tp, p2putil.NewEphemeralStore())
 	if err != nil {
 		tb.Fatal(err)
 	}

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -70,7 +70,7 @@ func NewSeed() Seed {
 	return SeedFromEntropy(entropy)
 }
 
-// A Store stores wallet state.
+// A Store stores wallet state. Implementations are assumed to be thread safe.
 type Store interface {
 	SeedIndex() uint64
 	AddAddress(addr types.Address, index uint64) error


### PR DESCRIPTION
This implements a minimal interface used by the syncer to store peer addresses.  Currently only an in memory store is supported but a store that writes to the disk will be added shortly.  It also adds a maintainHealthyPeerSet method on Syncer which runs as a goroutine that retrieves peers from the store and connects to them if the peer count is less than 8.