### PR TITLE
v2: Add peer discovery mechanism and RPC methods

### DIFF
--- a/cmd/siad/node.go
+++ b/cmd/siad/node.go
@@ -82,7 +82,7 @@ func newNode(addr, dir string, c consensus.Checkpoint) (*node, error) {
 	seed := wallet.NewSeed()
 
 	syncerDir := filepath.Join(dir, "p2p")
-	if err := os.MkdirAll(p2pDir, 0700); err != nil {
+	if err := os.MkdirAll(syncerDir, 0700); err != nil {
 		return nil, err
 	}
 	syncerStore, err := p2putil.NewJSONStore(syncerDir)

--- a/internal/p2putil/store.go
+++ b/internal/p2putil/store.go
@@ -32,6 +32,20 @@ func (s *EphemeralStore) RandomPeer() (string, error) {
 	return "", errors.New("no peers in list")
 }
 
+// RandomPeers implements p2p.SyncerStore.
+func (s *EphemeralStore) RandomPeers(n int) (peers []string, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for peer := range s.peers {
+		if n <= 0 {
+			break
+		}
+		peers = append(peers, peer)
+		n--
+	}
+	return
+}
+
 // NewEphemeralStore returns a new EphemeralStore.
 func NewEphemeralStore() *EphemeralStore {
 	return &EphemeralStore{


### PR DESCRIPTION
This adds a GetPeers method to the syncer RPC interface.  Clients requests the amount of peers they want and the server sends back the addresses of that many peers from their peer list.  Then, in maintainHealthyPeerSet, if we are already connected to the the random peer from the store, we call getPeers on a random one of our peers.