### PR TITLE
v2: Add peer manager to handle peer misbehavior

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"go.sia.tech/core/consensus"
-	"go.sia.tech/core/net/gateway"
 	"go.sia.tech/core/types"
 	"go.sia.tech/siad/v2/wallet"
 
@@ -43,7 +42,7 @@ type Wallet interface {
 // A Syncer can connect to other peers and synchronize the blockchain.
 type Syncer interface {
 	Addr() string
-	Peers() []gateway.Header
+	Peers() []string
 	Connect(addr string) error
 	BroadcastTransaction(txn types.Transaction, dependsOn []types.Transaction)
 }
@@ -179,7 +178,7 @@ func (s *Server) syncerPeersHandler(w http.ResponseWriter, req *http.Request, _ 
 	sps := make([]SyncerPeer, len(ps))
 	for i, peer := range ps {
 		sps[i] = SyncerPeer{
-			NetAddress: peer.NetAddress,
+			NetAddress: peer,
 		}
 	}
 	writeJSON(w, sps)

--- a/cmd/siad/node.go
+++ b/cmd/siad/node.go
@@ -81,15 +81,6 @@ func newNode(addr, dir string, c consensus.Checkpoint) (*node, error) {
 	}
 	seed := wallet.NewSeed()
 
-	syncerDir := filepath.Join(dir, "p2p")
-	if err := os.MkdirAll(syncerDir, 0700); err != nil {
-		return nil, err
-	}
-	syncerStore, err := p2putil.NewJSONStore(syncerDir)
-	if err != nil {
-		return nil, err
-	}
-
 	cm := chain.NewManager(chainStore, tip.Context)
 	tp := txpool.New(tip.Context)
 	cm.AddSubscriber(tp, cm.Tip())
@@ -101,7 +92,15 @@ func newNode(addr, dir string, c consensus.Checkpoint) (*node, error) {
 	m := cpuminer.New(tip.Context, w.NextAddress(), tp)
 	cm.AddSubscriber(m, cm.Tip())
 
-	s, err := p2p.NewSyncer(addr, genesisBlock.ID(), cm, tp, syncerStore)
+	p2pDir := filepath.Join(dir, "p2p")
+	if err := os.MkdirAll(p2pDir, 0700); err != nil {
+		return nil, err
+	}
+	peerStore, err := p2putil.NewJSONStore(p2pDir)
+	if err != nil {
+		return nil, err
+	}
+	s, err := p2p.NewSyncer(addr, genesisBlock.ID(), cm, tp, peerStore)
 	if err != nil {
 		return nil, err
 	}

--- a/p2p/peermanager.go
+++ b/p2p/peermanager.go
@@ -1,0 +1,106 @@
+package p2p
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"sync"
+	"time"
+)
+
+// PeerInfo tracks information about a peer.
+type PeerInfo struct {
+	NetAddress     string
+	LastSeen       time.Time
+	FailedConnects int
+	Banscore       int
+	Blacklisted    bool
+}
+
+func (peer PeerInfo) isGood() bool {
+	const (
+		maxBanscore       = 100
+		maxFailedConnects = 3
+	)
+	return !peer.Blacklisted && peer.Banscore <= maxBanscore && peer.FailedConnects <= maxFailedConnects
+}
+
+// A PeerStore stores peer information.
+type PeerStore interface {
+	AddPeer(addr string) error
+	Info(addr string) PeerInfo
+	UpdatePeer(addr string, fn func(*PeerInfo)) error
+	RandomPeers(max int, filter func(PeerInfo) bool) ([]PeerInfo, error)
+}
+
+// A PeerManager tracks information about potential network peers.
+type PeerManager struct {
+	store PeerStore
+	mu    sync.Mutex
+}
+
+// AddPeer adds a new peer to the manager.
+func (pm *PeerManager) AddPeer(addr string) error {
+	if _, _, err := net.SplitHostPort(addr); err != nil {
+		return fmt.Errorf("invalid peer address: %w", err)
+	}
+	return pm.store.AddPeer(addr)
+}
+
+// Info returns everything known about a given peer.
+func (pm *PeerManager) Info(addr string) PeerInfo {
+	return pm.store.Info(addr)
+}
+
+// RandomGoodPeers returns up to n peers that are likely to be connectable.
+func (pm *PeerManager) RandomGoodPeers(n int) []string {
+	peers, _ := pm.store.RandomPeers(n, (PeerInfo).isGood)
+	var addrs []string
+	for _, peer := range peers {
+		addrs = append(addrs, peer.NetAddress)
+	}
+	return addrs
+}
+
+// RandomGoodPeer returns a random peer that is likely to be connectable.
+func (pm *PeerManager) RandomGoodPeer() (string, error) {
+	ps := pm.RandomGoodPeers(1)
+	if len(ps) != 1 {
+		return "", errors.New("no good peers")
+	}
+	return ps[0], nil
+}
+
+func (pm *PeerManager) update(addr string, fn func(peer *PeerInfo)) {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+	err := pm.store.UpdatePeer(addr, fn)
+	_ = err // TODO: log?
+}
+
+// NoteSeen updates the peers last seen time to the current time.
+func (pm *PeerManager) NoteSeen(addr string) {
+	pm.update(addr, func(peer *PeerInfo) { peer.LastSeen = time.Now() })
+}
+
+// NoteFailedConnection increments the failed connects count of a peer.
+func (pm *PeerManager) NoteFailedConnection(addr string) {
+	pm.update(addr, func(peer *PeerInfo) { peer.FailedConnects++ })
+}
+
+// IncreaseBanscore increases the banscore of a peer by the specified amount.
+func (pm *PeerManager) IncreaseBanscore(addr string, score int) {
+	pm.update(addr, func(peer *PeerInfo) { peer.Banscore += score })
+}
+
+// Blacklist blacklists a peer.
+func (pm *PeerManager) Blacklist(addr string) {
+	pm.update(addr, func(peer *PeerInfo) { peer.Blacklisted = true })
+}
+
+// NewPeerManager initializes a PeerManager using the provided store.
+func NewPeerManager(store PeerStore) *PeerManager {
+	return &PeerManager{
+		store: store,
+	}
+}

--- a/p2p/syncer_test.go
+++ b/p2p/syncer_test.go
@@ -1,4 +1,4 @@
-package p2p
+package p2p_test
 
 import (
 	"context"
@@ -14,6 +14,7 @@ import (
 	"go.sia.tech/siad/v2/internal/cpuminer"
 	"go.sia.tech/siad/v2/internal/p2putil"
 	"go.sia.tech/siad/v2/internal/walletutil"
+	"go.sia.tech/siad/v2/p2p"
 	"go.sia.tech/siad/v2/txpool"
 	"go.sia.tech/siad/v2/wallet"
 )
@@ -23,7 +24,7 @@ type testNode struct {
 	c      *chain.Manager
 	cs     chain.ManagerStore
 	tp     *txpool.Pool
-	s      *Syncer
+	s      *p2p.Syncer
 	w      *wallet.HotWallet
 	m      *cpuminer.CPUMiner
 }
@@ -106,7 +107,7 @@ func newTestNode(tb testing.TB, genesisID types.BlockID, c consensus.Checkpoint)
 	cm.AddSubscriber(ws, cm.Tip())
 	m := cpuminer.New(c.Context, w.NextAddress(), tp)
 	cm.AddSubscriber(m, cm.Tip())
-	s, err := NewSyncer(":0", genesisID, cm, tp, p2putil.NewEphemeralStore())
+	s, err := p2p.NewSyncer(":0", genesisID, cm, tp, p2putil.NewEphemeralStore())
 	if err != nil {
 		tb.Fatal(err)
 	}
@@ -220,7 +221,7 @@ func TestCheckpoint(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	checkpointIndex := n1.c.Tip()
-	checkpoint, err := DownloadCheckpoint(ctx, n1.s.Addr(), genesisBlock.ID(), checkpointIndex)
+	checkpoint, err := p2p.DownloadCheckpoint(ctx, n1.s.Addr(), genesisBlock.ID(), checkpointIndex)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This adds a new PeerManager interface designed to be used to handle misbehaving peers.  In the p2putil.DefaultPeerManager, peers start out with 0 failed connections and a banscore of 0.  If we have problems communicating with them over RPC or the data they give us is bad, their banscore is increased.   Once the banscore exceeds maxBanscore, they are blacklisted, disconnected from, and cannot be connected to again.  If we have more than maxFailedConnects failed connections with them, we also blacklist them and stop trying to connect to them.  It also keeps track of the last interaction time with the peer as advised in https://github.com/SiaFoundation/siad/pull/60#pullrequestreview-832007297 but I am not exactly sure what to use this for.  Also, right now this code works on a per NetAddress (IP + port) basis but I think it should be purely on a IP basis to increase the cost of spam/harming the network.