### PR TITLE
p2p: Update Syncer to reflect gateway.Header refactor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/julienschmidt/httprouter v1.3.0
-	go.sia.tech/core v0.0.0-20211216234639-0de1d2a57d5a
+	go.sia.tech/core v0.0.0-20220108020438-629a2d2770e2
 	lukechampine.com/flagg v1.1.1
 	lukechampine.com/frand v1.4.2
 )

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da h1:KjTM2ks9d14ZYCvmH
 github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da/go.mod h1:eHEWzANqSiWQsof+nXEI9bUVUyV6F53Fp89EuCh2EAA=
 github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
-go.sia.tech/core v0.0.0-20211216234639-0de1d2a57d5a h1:KjVW8kyhYA7Xwa3gBOUlQlPCwsaT3PpgmD3VQ3+xXzo=
-go.sia.tech/core v0.0.0-20211216234639-0de1d2a57d5a/go.mod h1:j0C8dWPAttVKfUyQryjWCah9ZYUbzkCamo7u4HSQAo4=
+go.sia.tech/core v0.0.0-20220108020438-629a2d2770e2 h1:DL5l1aXYSfmtH2P3A08JWfrrt6v6tEQokL1yWQP8cY8=
+go.sia.tech/core v0.0.0-20220108020438-629a2d2770e2/go.mod h1:j0C8dWPAttVKfUyQryjWCah9ZYUbzkCamo7u4HSQAo4=
 golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20211209193657-4570a0811e8b h1:QAqMVf3pSa6eeTsuklijukjXBlj7Es2QQplab+/RbQ4=
 golang.org/x/crypto v0.0.0-20211209193657-4570a0811e8b/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=

--- a/p2p/checkpoint.go
+++ b/p2p/checkpoint.go
@@ -10,7 +10,6 @@ import (
 	"go.sia.tech/core/net/gateway"
 	"go.sia.tech/core/net/rpc"
 	"go.sia.tech/core/types"
-	"lukechampine.com/frand"
 )
 
 // DownloadCheckpoint connects to addr and downloads the checkpoint at the
@@ -31,12 +30,7 @@ func DownloadCheckpoint(ctx context.Context, addr string, genesisID types.BlockI
 		<-ctx.Done()
 		conn.Close()
 	}()
-	ourHeader := gateway.Header{
-		GenesisID:  genesisID,
-		NetAddress: conn.LocalAddr().String(),
-	}
-	frand.Read(ourHeader.UniqueID[:])
-	peer, err := gateway.DialSession(conn, ourHeader)
+	peer, err := gateway.DialSession(conn, genesisID, gateway.GenerateUniqueID())
 	if err != nil {
 		return consensus.Checkpoint{}, fmt.Errorf("couldn't establish session with peer: %w", err)
 	}

--- a/p2p/syncer_test.go
+++ b/p2p/syncer_test.go
@@ -38,10 +38,9 @@ func (tn *testNode) run() {
 
 func (tn *testNode) Close() error {
 	// signal miner to stop, and wait for it to exit
-	if atomic.CompareAndSwapInt32(&tn.mining, 1, 2) {
-		for atomic.LoadInt32(&tn.mining) != 3 {
-			time.Sleep(100 * time.Millisecond)
-		}
+	atomic.StoreInt32(&tn.mining, 2)
+	for atomic.LoadInt32(&tn.mining) != 3 {
+		time.Sleep(100 * time.Millisecond)
 	}
 	return tn.s.Close()
 }
@@ -175,7 +174,7 @@ func TestNetwork(t *testing.T) {
 	// since we are mining with low difficulty, the chains may have an identical
 	// amount of work; if so, mine a little more on one chain
 	vc1, _ := n1.c.TipContext()
-	vc2, _ := n1.c.TipContext()
+	vc2, _ := n2.c.TipContext()
 	if vc1.TotalWork.Cmp(vc2.TotalWork) == 0 {
 		n1.startMining()
 		for n1.c.Tip() == vc1.Index {


### PR DESCRIPTION
Some other minor cleanups in here as well, mainly moving from using `string` for peers to using the `gateway.Session` directly.