### PR TITLE
ci: add nightly v2 testing

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,28 @@
+name: Nightly v2
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        go-version: [ '1.16', '1.17' ]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: 'v2-devel' # checkout v2-devel branch, scheduled actions only run on the default branch
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: test
+        uses: n8maninger/action-golang-test@v1
+        with:
+          args: "-race;-count=100;-timeout=30m;-failfast"
+          skip-go-install: true
+          show-package-output: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: test
-        uses: n8maninger/action-golang-test@503bdd1b410aa26740cad03f1214abc8beef5496
+        uses: n8maninger/action-golang-test@v1
         with:
           args: "-race;-failfast;-tags=testing debug netgo"


### PR DESCRIPTION
Runs the test suite nightly with -count=1000 to try and detect NDFs. The workflow must be on the master branch for scheduling, but the `v2-devel` branch will be checked out on run.