### PR TITLE
Add Pool.AcceptTransactionSet and HotWallet.Address

### DIFF
--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -94,6 +94,17 @@ func (w *HotWallet) Balance() types.Currency {
 	return sum
 }
 
+// Address returns the last address added to the wallet.
+func (w *HotWallet) Address() types.Address {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	index := w.store.SeedIndex()
+	if index > 0 {
+		index--
+	}
+	return types.StandardAddress(w.seed.PublicKey(index))
+}
+
 // NextAddress returns an address controlled by the wallet.
 func (w *HotWallet) NextAddress() types.Address {
 	w.mu.Lock()


### PR DESCRIPTION
+ Adds `Pool.AcceptTransactionSet` to validate and add a transaction set to the transaction pool
+ Adds `HotWallet.Address` to get the address of the last address added to the wallet

Off-topic, but should the store interface be changed to work on spend policies rather than only indices?