### PR TITLE
Update FileContract fields

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/julienschmidt/httprouter v1.3.0
-	go.sia.tech/core v0.0.0-20220216154908-3d90cd95058d
+	go.sia.tech/core v0.0.0-20220224172916-b39a733abe19
 	golang.org/x/crypto v0.0.0-20211209193657-4570a0811e8b
 	lukechampine.com/flagg v1.1.1
 	lukechampine.com/frand v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4d
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 go.sia.tech/core v0.0.0-20220216154908-3d90cd95058d h1:KVbZF70LP+3SPTnGhA048dlS3nKslOvXWOoYw04o98M=
 go.sia.tech/core v0.0.0-20220216154908-3d90cd95058d/go.mod h1:j0C8dWPAttVKfUyQryjWCah9ZYUbzkCamo7u4HSQAo4=
+go.sia.tech/core v0.0.0-20220224172916-b39a733abe19 h1:uaDdoN7w7FgBqwAIWc5UfszUdC+s7vIKAjffOyzLrXk=
+go.sia.tech/core v0.0.0-20220224172916-b39a733abe19/go.mod h1:j0C8dWPAttVKfUyQryjWCah9ZYUbzkCamo7u4HSQAo4=
 golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20211209193657-4570a0811e8b h1:QAqMVf3pSa6eeTsuklijukjXBlj7Es2QQplab+/RbQ4=
 golang.org/x/crypto v0.0.0-20211209193657-4570a0811e8b/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=

--- a/renter/program.go
+++ b/renter/program.go
@@ -87,7 +87,7 @@ func (s *Session) ExecuteProgram(program Program, input []byte, payment PaymentM
 
 	var response rhp.RPCExecuteInstrResponse
 	for i := range program.Instructions {
-		// reset the deadline for each executed instruction.
+		// reset the deadline for each executed instruction
 		stream.SetDeadline(time.Now().Add(5 * time.Minute))
 		if err = rpc.ReadResponse(stream, &response); err != nil {
 			return fmt.Errorf("failed to read execute program response %v: %w", i, err)
@@ -103,7 +103,7 @@ func (s *Session) ExecuteProgram(program Program, input []byte, payment PaymentM
 		}
 
 		// discard the remaining output in case the execute function didn't
-		// consume it.
+		// consume it
 		io.Copy(io.Discard, lr)
 	}
 
@@ -111,7 +111,7 @@ func (s *Session) ExecuteProgram(program Program, input []byte, payment PaymentM
 		return nil
 	}
 
-	// reset the deadline for contract finalization.
+	// reset the deadline for contract finalization
 	stream.SetDeadline(time.Now().Add(2 * time.Minute))
 
 	// Finalize the program by updating the contract revision with additional
@@ -133,10 +133,9 @@ func (s *Session) ExecuteProgram(program Program, input []byte, payment PaymentM
 		Signature:         program.RenterKey.SignHash(contractHash),
 		NewRevisionNumber: rev.RevisionNumber,
 		NewOutputs: rhp.ContractOutputs{
-			MissedHostValue:   rev.MissedHostOutput.Value,
-			MissedRenterValue: rev.MissedRenterOutput.Value,
-			ValidHostValue:    rev.ValidHostOutput.Value,
-			ValidRenterValue:  rev.ValidRenterOutput.Value,
+			RenterValue:     rev.RenterOutput.Value,
+			HostValue:       rev.HostOutput.Value,
+			MissedHostValue: rev.MissedHostValue,
 		},
 	}
 


### PR DESCRIPTION
~~Adds the initial cost to the renter for data already stored in the contract back to the Renew RPC. For a renewal that extends the duration of a contract, the renter must pay additional storage and the host must risk additional collateral.~~

Updates FileContract usage in the RHP to match SiaFoundation/core#57