### PR TITLE
Make TestNetwork non-concurrent

### DIFF
--- a/p2p/syncer_test.go
+++ b/p2p/syncer_test.go
@@ -3,7 +3,6 @@ package p2p_test
 import (
 	"context"
 	"errors"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -17,31 +16,25 @@ import (
 	"go.sia.tech/siad/v2/p2p"
 	"go.sia.tech/siad/v2/txpool"
 	"go.sia.tech/siad/v2/wallet"
+	"lukechampine.com/frand"
 )
 
 type testNode struct {
-	mining int32
-	c      *chain.Manager
-	cs     chain.ManagerStore
-	tp     *txpool.Pool
-	s      *p2p.Syncer
-	w      *wallet.HotWallet
-	m      *cpuminer.CPUMiner
+	c  *chain.Manager
+	cs chain.ManagerStore
+	tp *txpool.Pool
+	s  *p2p.Syncer
+	w  *wallet.HotWallet
+	m  *cpuminer.CPUMiner
 }
 
 func (tn *testNode) run() {
-	go tn.mine()
 	if err := tn.s.Run(); err != nil {
 		panic(err)
 	}
 }
 
 func (tn *testNode) Close() error {
-	// signal miner to stop, and wait for it to exit
-	atomic.StoreInt32(&tn.mining, 2)
-	for atomic.LoadInt32(&tn.mining) != 3 {
-		time.Sleep(100 * time.Millisecond)
-	}
 	return tn.s.Close()
 }
 
@@ -65,9 +58,6 @@ func (tn *testNode) send(amount types.Currency, dest types.Address) error {
 	return nil
 }
 
-func (tn *testNode) startMining() bool { return atomic.CompareAndSwapInt32(&tn.mining, 0, 1) }
-func (tn *testNode) stopMining() bool  { return atomic.CompareAndSwapInt32(&tn.mining, 1, 0) }
-
 func (tn *testNode) mineBlock() error {
 again:
 	b := tn.m.MineBlock()
@@ -80,20 +70,6 @@ again:
 	tn.s.BroadcastBlock(b)
 	time.Sleep(10 * time.Millisecond)
 	return nil
-}
-
-func (tn *testNode) mine() {
-	for {
-		// wait for permission
-		for atomic.LoadInt32(&tn.mining) == 0 {
-			time.Sleep(100 * time.Millisecond)
-		}
-		if atomic.CompareAndSwapInt32(&tn.mining, 2, 3) {
-			return // shutdown
-		}
-
-		tn.mineBlock()
-	}
 }
 
 func newTestNode(tb testing.TB, genesisID types.BlockID, c consensus.Checkpoint) *testNode {
@@ -139,48 +115,52 @@ func TestNetwork(t *testing.T) {
 	n2 := newTestNode(t, genesisBlock.ID(), genesis)
 	defer n2.Close()
 	go n2.run()
-	n1.startMining()
-	n2.startMining()
+
+	mineOnRandomNode := func() {
+		if frand.Intn(2) == 0 {
+			n1.mineBlock()
+		} else {
+			n2.mineBlock()
+		}
+	}
 
 	// connect the nodes after a few blocks have been mined
 	for n1.c.Tip().Height < 10 || n2.c.Tip().Height < 10 {
-		time.Sleep(5 * time.Millisecond)
+		mineOnRandomNode()
 	}
 	if err := n1.s.Connect(n2.s.Addr()); err != nil {
 		t.Fatal(err)
 	}
 
-	// mine until both nodes have a balance
+	// continue mining until both nodes have a balance
 	for n1.w.Balance().IsZero() || n2.w.Balance().IsZero() {
-		time.Sleep(5 * time.Millisecond)
+		mineOnRandomNode()
 	}
 
-	// simulate some chain activity by spamming simple txns, stopping after both nodes have sent 10 txns
+	// simulate some chain activity by mining and broadcasting simple txns,
+	// stopping after both nodes have sent 10 txns
 	n1addr := n1.w.NextAddress()
 	n2addr := n2.w.NextAddress()
 	for s1, s2 := 0, 0; s1 < 10 || s2 < 10; {
-		time.Sleep(5 * time.Millisecond)
-		if n1.send(types.Siacoins(7), n2addr) == nil {
-			s1++
-		}
-		if n2.send(types.Siacoins(9), n1addr) == nil {
-			s2++
+		if frand.Intn(2) == 0 {
+			if n1.send(types.Siacoins(7), n2addr) == nil {
+				s1++
+			}
+		} else {
+			if n2.send(types.Siacoins(9), n1addr) == nil {
+				s2++
+			}
+			mineOnRandomNode()
 		}
 	}
-	n1.stopMining()
-	n2.stopMining()
-	time.Sleep(10 * time.Millisecond)
+	mineOnRandomNode()
 
 	// since we are mining with low difficulty, the chains may have an identical
 	// amount of work; if so, mine a little more on one chain
 	vc1 := n1.c.TipContext()
 	vc2 := n2.c.TipContext()
 	if vc1.TotalWork.Cmp(vc2.TotalWork) == 0 {
-		n1.startMining()
-		for n1.c.Tip() == vc1.Index {
-			time.Sleep(5 * time.Millisecond)
-		}
-		n1.stopMining()
+		n1.mineBlock()
 	}
 
 	// nodes should synchronize within 5 seconds


### PR DESCRIPTION
`TestNetwork` used to spawn goroutines that mined in the background in order to test synchronization. This works fine when testing locally, but fails nondeterministically on CI machines. This PR removes concurrency from the test, instead manually selected nodes to mine via `frand`. As a result, it runs a bit slower (and does not model real-world conditions as accurately), but it *should* pass on CI every time.