### PR TITLE
Flesh out core renter RPCs

### DIFF
--- a/api/renterd/api.go
+++ b/api/renterd/api.go
@@ -20,15 +20,14 @@ type SyncerConnectRequest struct {
 	NetAddress string `json:"netAddress"`
 }
 
-// A ContractsScanRequest contains the information of the host we are dialing
-// for contract related requests.
-type ContractsScanRequest struct {
+// An RHPScanRequest contains the address and pubkey of the host to scan.
+type RHPScanRequest struct {
 	NetAddress string          `json:"netAddress"`
 	HostKey    types.PublicKey `json:"hostKey"`
 }
 
-// A ContractsFormRequest requests that the host create a contract.
-type ContractsFormRequest struct {
+// An RHPFormRequest requests that the host create a contract.
+type RHPFormRequest struct {
 	RenterKey    types.PrivateKey `json:"renterKey"`
 	NetAddress   string           `json:"netAddress"`
 	HostKey      types.PublicKey  `json:"hostKey"`
@@ -38,22 +37,15 @@ type ContractsFormRequest struct {
 	HostSettings rhp.HostSettings `json:"hostSettings"`
 }
 
-// A ContractsFormResponse is the response to /contract/form. It contains the
-// formed contract and the parent transactions.
-type ContractsFormResponse struct {
+// An RHPFormResponse is the response to /rhp/form. It contains the formed
+// contract and the parent transactions.
+type RHPFormResponse struct {
 	Contract rhp.Contract      `json:"contract"`
 	Parent   types.Transaction `json:"parent"`
 }
 
-// A ContractsRenewResponse is the response to /contract/renew. It contains the
-// formed contract and the parent transactions.
-type ContractsRenewResponse struct {
-	Contract rhp.Contract      `json:"contract"`
-	Parent   types.Transaction `json:"parent"`
-}
-
-// A ContractsRenewRequest requests that the host renew a contract.
-type ContractsRenewRequest struct {
+// An RHPRenewRequest requests that the host renew a contract.
+type RHPRenewRequest struct {
 	RenterKey      types.PrivateKey           `json:"renterKey"`
 	NetAddress     string                     `json:"netAddress"`
 	HostKey        types.PublicKey            `json:"hostKey"`
@@ -62,4 +54,39 @@ type ContractsRenewRequest struct {
 	Extension      uint64                     `json:"extension"`
 	Contract       types.FileContractRevision `json:"contract"`
 	HostSettings   rhp.HostSettings           `json:"hostSettings"`
+}
+
+// An RHPRenewResponse is the response to /rhp/renew. It contains the formed
+// contract and the parent transaction.
+type RHPRenewResponse struct {
+	Contract rhp.Contract      `json:"contract"`
+	Parent   types.Transaction `json:"parent"`
+}
+
+// An RHPReadRequest invokes the Read RPC on a host. The raw response is
+// streamed to the client.
+type RHPReadRequest struct {
+	HostKey    types.PublicKey             `json:"hostKey"`
+	NetAddress string                      `json:"netAddress"`
+	ContractID types.ElementID             `json:"contractID"`
+	RenterKey  types.PrivateKey            `json:"renterKey"`
+	MaxPrice   types.Currency              `json:"maxPrice"`
+	Sections   []rhp.RPCReadRequestSection `json:"sections"`
+}
+
+// An RHPAppendRequest invokes the Write RPC on a host, appending one sector to
+// the contract. The sector data should be included alongside this request
+// object as a multipart form.
+type RHPAppendRequest struct {
+	HostKey    types.PublicKey  `json:"hostKey"`
+	NetAddress string           `json:"netAddress"`
+	ContractID types.ElementID  `json:"contractID"`
+	RenterKey  types.PrivateKey `json:"renterKey"`
+	MaxPrice   types.Currency   `json:"maxPrice"`
+}
+
+// An RHPAppendResponse is the response to /rhp/append. It contains the Merkle
+// root of the appended sector.
+type RHPAppendResponse struct {
+	SectorRoot types.Hash256 `json:"sectorRoot"`
 }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/julienschmidt/httprouter v1.3.0
-	go.sia.tech/core v0.0.0-20220301201530-ed3369a3d726
+	go.sia.tech/core v0.0.0-20220317023259-51930552ea5a
 	golang.org/x/crypto v0.0.0-20211209193657-4570a0811e8b
 	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1
 	lukechampine.com/flagg v1.1.1
@@ -12,6 +12,8 @@ require (
 )
 
 require (
+	filippo.io/edwards25519 v1.0.0-rc.1 // indirect
 	github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da // indirect
+	github.com/hdevalence/ed25519consensus v0.0.0-20220222234857-c00d1f31bab3 // indirect
 	golang.org/x/sys v0.0.0-20211214234402-4825e8c3871d // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,13 @@
+filippo.io/edwards25519 v1.0.0-rc.1 h1:m0VOOB23frXZvAOK44usCgLWvtsxIoMCTBGJZlpmGfU=
+filippo.io/edwards25519 v1.0.0-rc.1/go.mod h1:N1IkdkCkiLB6tki+MYJoSx2JTY9NUlxZE7eHn5EwJns=
 github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da h1:KjTM2ks9d14ZYCvmHS9iAKVt9AyzRSqNU1qabPih5BY=
 github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da/go.mod h1:eHEWzANqSiWQsof+nXEI9bUVUyV6F53Fp89EuCh2EAA=
+github.com/hdevalence/ed25519consensus v0.0.0-20220222234857-c00d1f31bab3 h1:aSVUgRRRtOrZOC1fYmY9gV0e9z/Iu+xNVSASWjsuyGU=
+github.com/hdevalence/ed25519consensus v0.0.0-20220222234857-c00d1f31bab3/go.mod h1:5PC6ZNPde8bBqU/ewGZig35+UIZtw9Ytxez8/q5ZyFE=
 github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
-go.sia.tech/core v0.0.0-20220301201530-ed3369a3d726 h1:aQquBihgXZXCex/bc3YVT8PKJj9jKkbwjARZUkEHRSw=
-go.sia.tech/core v0.0.0-20220301201530-ed3369a3d726/go.mod h1:j0C8dWPAttVKfUyQryjWCah9ZYUbzkCamo7u4HSQAo4=
+go.sia.tech/core v0.0.0-20220317023259-51930552ea5a h1:gmIOp7Oz0woJjKT/M1UPbF4X0MgdFPl+Cw9FAlmmhbE=
+go.sia.tech/core v0.0.0-20220317023259-51930552ea5a/go.mod h1:DzB1dUn6PzFGcWMwnuGD6fjxGGRE8vor3byCIX7pZUU=
 golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20211209193657-4570a0811e8b h1:QAqMVf3pSa6eeTsuklijukjXBlj7Es2QQplab+/RbQ4=
 golang.org/x/crypto v0.0.0-20211209193657-4570a0811e8b/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=

--- a/renter/payment.go
+++ b/renter/payment.go
@@ -41,8 +41,7 @@ func (s *Session) payByContract(stream *mux.Stream, payment *payByContract, amou
 	}
 
 	// sign the revision and send it to the host
-	vc := s.cm.TipContext()
-	revisionHash := vc.ContractSigHash(revision)
+	revisionHash := s.cm.TipContext().ContractSigHash(revision)
 	req := &rhp.PayByContractRequest{
 		RefundAccount: payment.refundAccountID,
 
@@ -111,11 +110,12 @@ func (s *Session) pay(stream *mux.Stream, payment PaymentMethod, amount types.Cu
 	}
 }
 
-// PayByContract returns a PaymentMethod that revises the provided contract.
-func (s *Session) PayByContract(contract *rhp.Contract, priv types.PrivateKey, refundAccountID types.PublicKey) PaymentMethod {
+// PayByContract returns a PaymentMethod that revises the currently-locked
+// contract.
+func (s *Session) PayByContract(refundAccountID types.PublicKey) PaymentMethod {
 	return &payByContract{
-		contract:        contract,
-		privkey:         priv,
+		contract:        &s.contract,
+		privkey:         s.renterKey,
 		hostKey:         s.hostKey,
 		refundAccountID: refundAccountID,
 	}


### PR DESCRIPTION
Adds the `Lock`, `Read`, and `Write` (well, `Append`) RPCs to `renter.Session`, and wires the latter up to the API. Also renames the `/contract` routes to `/rhp`, and adds `Client` methods for all `/rhp` endpoints.

This should provide all the functionality we need to build a minimal renter UI.