### PR TITLE
fix: reference error in WalletTransactionGet

### DIFF
--- a/node/api/client/wallet.go
+++ b/node/api/client/wallet.go
@@ -205,7 +205,7 @@ func (c *Client) WalletTransactionsGet(startHeight types.BlockHeight, endHeight 
 // WalletTransactionGet requests the /wallet/transaction/:id api resource for a
 // certain TransactionID.
 func (c *Client) WalletTransactionGet(id types.TransactionID) (wtg api.WalletTransactionGETid, err error) {
-	err = c.get("/wallet/transaction/"+id.String(), wtg)
+	err = c.get("/wallet/transaction/"+id.String(), &wtg)
 	return
 }
 


### PR DESCRIPTION
Hit an unexpected error with `WalletTransactionGet`:

`could not read response; json: Unmarshal(non-pointer api.WalletTransactionGETid)`

Looks like a missing `&` operator.