### PR TITLE
v2: Make ChainSim.MineBlock add more sophisticated random transactions

### DIFF
--- a/internal/chainutil/chainutil.go
+++ b/internal/chainutil/chainutil.go
@@ -281,7 +281,7 @@ func (cs *ChainSim) MineBlock() types.Block {
 		} else {
 			// revise
 			rev := fc.FileContract
-			rev.Filesize += 1
+			rev.Filesize += 5
 			txn := types.Transaction{
 				FileContractRevisions: []types.FileContractRevision{{
 					Parent:   fc,


### PR DESCRIPTION
Add more random types of transactions (spending SF, file contract revisions/resolutions) when a block is mined with ChainSim.MineBlock.  This should make tests using ChainSim more robust.  Potential other candidates for inclusion could be foundation address updates and attestations.