### PR TITLE
Add option to send mined coins to custom address

### DIFF
--- a/cmd/siac/main.go
+++ b/cmd/siac/main.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strconv"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -40,19 +39,6 @@ Subcommands:
     syncer
 `
 	versionUsage = rootUsage
-
-	addressUsage = `Usage:
-    siac [flags] address [flags] [action]
-
-Actions:
-    generate         generate an address from a seed
-`
-
-	addressGenerateUsage = `Usage:
-    siac [flags] address [flags] generate [index]
-
-Generate an address based on the seed entered via stdin and the provided index.
-`
 
 	walletUsage = `Usage:
     siac [flags] wallet [flags] [action]
@@ -241,9 +227,6 @@ func main() {
 
 	versionCmd := flagg.New("version", versionUsage)
 
-	addressCmd := flagg.New("address", addressUsage)
-	addressGenerateCmd := flagg.New("generate", addressGenerateUsage)
-
 	walletCmd := flagg.New("wallet", walletUsage)
 	walletBalanceCmd := flagg.New("balance", walletBalanceUsage)
 	walletBalanceCmd.BoolVar(&exactCurrency, "exact", false, "print balance in Hastings")
@@ -266,12 +249,6 @@ func main() {
 		Cmd: rootCmd,
 		Sub: []flagg.Tree{
 			{Cmd: versionCmd},
-			{
-				Cmd: addressCmd,
-				Sub: []flagg.Tree{
-					{Cmd: addressGenerateCmd},
-				},
-			},
 			{
 				Cmd: walletCmd,
 				Sub: []flagg.Tree{
@@ -310,19 +287,6 @@ func main() {
 	case versionCmd:
 		log.Printf("siac v2.0.0\nCommit:     %s\nGo version: %s %s/%s\nBuild Date: %s\n",
 			githash, runtime.Version(), runtime.GOOS, runtime.GOARCH, builddate)
-
-	case addressCmd:
-		cmd.Usage()
-	case addressGenerateCmd:
-		if len(args) != 1 {
-			cmd.Usage()
-			return
-		}
-
-		seed := getSeed()
-		index, err := strconv.ParseUint(args[0], 10, 64)
-		check("Couldn't parse index:", err)
-		fmt.Println(seed.PublicKey(index))
 
 	case walletCmd:
 		cmd.Usage()

--- a/cmd/siac/main.go
+++ b/cmd/siac/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -39,6 +40,19 @@ Subcommands:
     syncer
 `
 	versionUsage = rootUsage
+
+	addressUsage = `Usage:
+    siac [flags] address [flags] [action]
+
+Actions:
+    generate         generate an address from a seed
+`
+
+	addressGenerateUsage = `Usage:
+    siac [flags] address [flags] generate [index]
+
+Generate an address based on the seed entered via stdin and the provided index.
+`
 
 	walletUsage = `Usage:
     siac [flags] wallet [flags] [action]
@@ -227,6 +241,9 @@ func main() {
 
 	versionCmd := flagg.New("version", versionUsage)
 
+	addressCmd := flagg.New("address", addressUsage)
+	addressGenerateCmd := flagg.New("generate", addressGenerateUsage)
+
 	walletCmd := flagg.New("wallet", walletUsage)
 	walletBalanceCmd := flagg.New("balance", walletBalanceUsage)
 	walletBalanceCmd.BoolVar(&exactCurrency, "exact", false, "print balance in Hastings")
@@ -249,6 +266,12 @@ func main() {
 		Cmd: rootCmd,
 		Sub: []flagg.Tree{
 			{Cmd: versionCmd},
+			{
+				Cmd: addressCmd,
+				Sub: []flagg.Tree{
+					{Cmd: addressGenerateCmd},
+				},
+			},
 			{
 				Cmd: walletCmd,
 				Sub: []flagg.Tree{
@@ -287,6 +310,19 @@ func main() {
 	case versionCmd:
 		log.Printf("siac v2.0.0\nCommit:     %s\nGo version: %s %s/%s\nBuild Date: %s\n",
 			githash, runtime.Version(), runtime.GOOS, runtime.GOARCH, builddate)
+
+	case addressCmd:
+		cmd.Usage()
+	case addressGenerateCmd:
+		if len(args) != 1 {
+			cmd.Usage()
+			return
+		}
+
+		seed := getSeed()
+		index, err := strconv.ParseUint(args[0], 10, 64)
+		check("Couldn't parse index:", err)
+		fmt.Println(seed.PublicKey(index))
 
 	case walletCmd:
 		cmd.Usage()

--- a/cmd/siad/main.go
+++ b/cmd/siad/main.go
@@ -70,6 +70,7 @@ func main() {
 	apiAddr := flag.String("http", "localhost:9980", "address to serve API on")
 	dir := flag.String("dir", ".", "directory to store node state in")
 	mine := flag.Bool("mine", false, "run CPU miner")
+	minerAddr := flag.String("miner-addr", types.VoidAddress.String(), "address to send block rewards to")
 	checkpoint := flag.String("checkpoint", "", "checkpoint to bootstrap from")
 	bootstrap := flag.String("bootstrap", "", "peer address or explorer URL to bootstrap from")
 	flag.Parse()
@@ -110,7 +111,7 @@ func main() {
 		}
 	}
 
-	n, err := newNode(*gatewayAddr, *dir, initCheckpoint)
+	n, err := newNode(*gatewayAddr, *dir, *minerAddr, initCheckpoint)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/siad/node.go
+++ b/cmd/siad/node.go
@@ -61,7 +61,7 @@ func (n *node) Close() error {
 	return nil
 }
 
-func newNode(addr, dir string, c consensus.Checkpoint) (*node, error) {
+func newNode(addr, dir, minerAddr string, c consensus.Checkpoint) (*node, error) {
 	chainDir := filepath.Join(dir, "chain")
 	if err := os.MkdirAll(chainDir, 0700); err != nil {
 		return nil, err
@@ -87,7 +87,11 @@ func newNode(addr, dir string, c consensus.Checkpoint) (*node, error) {
 		return nil, fmt.Errorf("couldn't resubscribe wallet at index %v: %w", walletTip, err)
 	}
 
-	m := cpuminer.New(tip.Context, types.VoidAddress, tp)
+	minerAddrParsed, err := types.ParseAddress(minerAddr)
+	if err != nil {
+		return nil, err
+	}
+	m := cpuminer.New(tip.Context, minerAddrParsed, tp)
 	cm.AddSubscriber(m, cm.Tip())
 
 	p2pDir := filepath.Join(dir, "p2p")


### PR DESCRIPTION
Adds a `minerAddr` option for the CPU miner in siad and adds the ability to generate addresses for a given seed and index to siac. 