### PR TITLE
Add domain and ip range blocking to HostDB's filtering system

### DIFF
--- a/doc/api/index.html.md
+++ b/doc/api/index.html.md
@@ -2544,7 +2544,13 @@ Returns the current filter mode of the hostDB and any filtered hosts.
   "hosts":
     [
       "ed25519:122218260fb74b20a8be3000ad56a931f7461ea990a6dc5676c31bdf65fc668f"  // string
-    ]
+    ],
+    "netaddresses":
+    [
+        "1.1.1.1",  // string
+        "1.0.0.0/8",  // string
+        "mooo.com",  // string
+    ],
 }
 
 ```
@@ -2553,6 +2559,9 @@ Can be either whitelist, blacklist, or disable.
 
 **hosts** | array of strings  
 Comma separated pubkeys.  
+
+**netaddresses** | array of strings  
+Comma separated list of IP addresses or domains to block.  
 
 ## /hostdb/filtermode [POST]
 > curl example  

--- a/modules/gateway/conn.go
+++ b/modules/gateway/conn.go
@@ -4,8 +4,7 @@ import (
 	"net"
 	"time"
 
-	"gitlab.com/NebulousLabs/monitor"
-
+	connmonitor "gitlab.com/NebulousLabs/monitor"
 	"go.sia.tech/siad/build"
 	"go.sia.tech/siad/modules"
 )

--- a/modules/renter.go
+++ b/modules/renter.go
@@ -1133,10 +1133,10 @@ type Renter interface {
 	FileList(siaPath SiaPath, recursive, cached bool, flf FileListFunc) error
 
 	// Filter returns the renter's hostdb's filterMode and filteredHosts
-	Filter() (FilterMode, map[string]types.SiaPublicKey, error)
+	Filter() (FilterMode, map[string]types.SiaPublicKey, []string, error)
 
 	// SetFilterMode sets the renter's hostdb filter mode
-	SetFilterMode(fm FilterMode, hosts []types.SiaPublicKey) error
+	SetFilterMode(fm FilterMode, hosts []types.SiaPublicKey, netAddresses []string) error
 
 	// Host provides the DB entry and score breakdown for the requested host.
 	Host(pk types.SiaPublicKey) (HostDBEntry, bool, error)
@@ -1312,10 +1312,10 @@ type HostDB interface {
 	EstimateHostScore(HostDBEntry, Allowance) (HostScoreBreakdown, error)
 
 	// Filter returns the hostdb's filterMode and filteredHosts
-	Filter() (FilterMode, map[string]types.SiaPublicKey, error)
+	Filter() (FilterMode, map[string]types.SiaPublicKey, []string, error)
 
 	// SetFilterMode sets the renter's hostdb filter mode
-	SetFilterMode(lm FilterMode, hosts []types.SiaPublicKey) error
+	SetFilterMode(lm FilterMode, hosts []types.SiaPublicKey, netAddresses []string) error
 
 	// Host returns the HostDBEntry for a given host.
 	Host(pk types.SiaPublicKey) (HostDBEntry, bool, error)

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -677,22 +677,22 @@ func (r *Renter) ActiveHosts() ([]modules.HostDBEntry, error) { return r.hostDB.
 func (r *Renter) AllHosts() ([]modules.HostDBEntry, error) { return r.hostDB.AllHosts() }
 
 // Filter returns the renter's hostdb's filterMode and filteredHosts
-func (r *Renter) Filter() (modules.FilterMode, map[string]types.SiaPublicKey, error) {
+func (r *Renter) Filter() (modules.FilterMode, map[string]types.SiaPublicKey, []string, error) {
 	var fm modules.FilterMode
 	hosts := make(map[string]types.SiaPublicKey)
 	if err := r.tg.Add(); err != nil {
-		return fm, hosts, err
+		return fm, hosts, nil, err
 	}
 	defer r.tg.Done()
-	fm, hosts, err := r.hostDB.Filter()
+	fm, hosts, netAddresses, err := r.hostDB.Filter()
 	if err != nil {
-		return fm, hosts, errors.AddContext(err, "error getting hostdb filter:")
+		return fm, hosts, netAddresses, errors.AddContext(err, "error getting hostdb filter:")
 	}
-	return fm, hosts, nil
+	return fm, hosts, netAddresses, nil
 }
 
 // SetFilterMode sets the renter's hostdb filter mode
-func (r *Renter) SetFilterMode(lm modules.FilterMode, hosts []types.SiaPublicKey) error {
+func (r *Renter) SetFilterMode(lm modules.FilterMode, hosts []types.SiaPublicKey, netAddresses []string) error {
 	if err := r.tg.Add(); err != nil {
 		return err
 	}
@@ -708,7 +708,7 @@ func (r *Renter) SetFilterMode(lm modules.FilterMode, hosts []types.SiaPublicKey
 	}
 
 	// Set list mode filter for the hostdb
-	if err := r.hostDB.SetFilterMode(lm, hosts); err != nil {
+	if err := r.hostDB.SetFilterMode(lm, hosts, netAddresses); err != nil {
 		return err
 	}
 

--- a/node/api/client/hostdb.go
+++ b/node/api/client/hostdb.go
@@ -33,11 +33,12 @@ func (c *Client) HostDbFilterModeGet() (hdfmg api.HostdbFilterModeGET, err error
 }
 
 // HostDbFilterModePost requests the /hostdb/filtermode POST endpoint
-func (c *Client) HostDbFilterModePost(fm modules.FilterMode, hosts []types.SiaPublicKey) (err error) {
+func (c *Client) HostDbFilterModePost(fm modules.FilterMode, hosts []types.SiaPublicKey, netAddresses []string) (err error) {
 	filterMode := fm.String()
 	hdblp := api.HostdbFilterModePOST{
-		FilterMode: filterMode,
-		Hosts:      hosts,
+		FilterMode:   filterMode,
+		Hosts:        hosts,
+		NetAddresses: netAddresses,
 	}
 
 	data, err := json.Marshal(hdblp)

--- a/node/api/hostdb.go
+++ b/node/api/hostdb.go
@@ -45,15 +45,17 @@ type (
 	// HostdbFilterModeGET contains the information about the HostDB's
 	// filtermode
 	HostdbFilterModeGET struct {
-		FilterMode string   `json:"filtermode"`
-		Hosts      []string `json:"hosts"`
+		FilterMode   string   `json:"filtermode"`
+		Hosts        []string `json:"hosts"`
+		NetAddresses []string `json:"netaddresses"`
 	}
 
 	// HostdbFilterModePOST contains the information needed to set the the
 	// FilterMode of the hostDB
 	HostdbFilterModePOST struct {
-		FilterMode string               `json:"filtermode"`
-		Hosts      []types.SiaPublicKey `json:"hosts"`
+		FilterMode   string               `json:"filtermode"`
+		Hosts        []types.SiaPublicKey `json:"hosts"`
+		NetAddresses []string             `json:"netaddresses"`
 	}
 )
 
@@ -168,7 +170,7 @@ func (api *API) hostdbHostsHandler(w http.ResponseWriter, _ *http.Request, ps ht
 // mode
 func (api *API) hostdbFilterModeHandlerGET(w http.ResponseWriter, _ *http.Request, _ httprouter.Params) {
 	// Get FilterMode
-	fm, hostMap, err := api.renter.Filter()
+	fm, hostMap, netAddresses, err := api.renter.Filter()
 	if err != nil {
 		WriteError(w, Error{"unable to get filter mode: " + err.Error()}, http.StatusBadRequest)
 		return
@@ -179,8 +181,9 @@ func (api *API) hostdbFilterModeHandlerGET(w http.ResponseWriter, _ *http.Reques
 		hosts = append(hosts, key)
 	}
 	WriteJSON(w, HostdbFilterModeGET{
-		FilterMode: fm.String(),
-		Hosts:      hosts,
+		FilterMode:   fm.String(),
+		Hosts:        hosts,
+		NetAddresses: netAddresses,
 	})
 }
 
@@ -202,7 +205,7 @@ func (api *API) hostdbFilterModeHandlerPOST(w http.ResponseWriter, req *http.Req
 	}
 
 	// Set list mode
-	if err := api.renter.SetFilterMode(fm, params.Hosts); err != nil {
+	if err := api.renter.SetFilterMode(fm, params.Hosts, params.NetAddresses); err != nil {
 		WriteError(w, Error{"failed to set the list mode: " + err.Error()}, http.StatusBadRequest)
 		return
 	}


### PR DESCRIPTION
Adds domain and IP address filtering capabilities to `SetFilterMode` in the HostDB.  Currently has some bugs that need to be ironed out.