### PR TITLE
Fix sector removal lock contention

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -93,6 +93,9 @@ linters-settings:
       - ptrToRefParam
       - underef
       - equalFold
+  gosec:
+    excludes:
+      - G307
 
 linters:
   disable-all: true

--- a/modules/host.go
+++ b/modules/host.go
@@ -451,10 +451,11 @@ type (
 		// information for that sector can be properly updated.
 		RemoveSector(sectorRoot crypto.Hash) error
 
-		// RemoveSectorBatch is a non-ACID performance optimization to remove a
-		// ton of sectors from the host all at once. This is necessary when
-		// clearing out an entire contract from the host.
-		RemoveSectorBatch(sectorRoots []crypto.Hash) error
+		// MarkSectorsForRemoval is a non-ACID performance optimization to
+		// remove a ton of sectors from the host. Works around lockups in the
+		// WAL by batching sectors to be removed over a period of time instead
+		// of all at once.
+		MarkSectorsForRemoval(sectorRoots []crypto.Hash) error
 
 		// RemoveStorageFolder will remove a storage folder from the host. All
 		// storage on the folder will be moved to other storage folders, meaning

--- a/modules/host/contractmanager/consts.go
+++ b/modules/host/contractmanager/consts.go
@@ -49,6 +49,10 @@ const (
 	// sectorOverflowFile is the path to the file used if a virtual sector's
 	// counter becomes greater than the max value of a uint16.
 	sectorOverflowFile = "sector_overflow.dat"
+
+	// sectorRemovalFile is the path to the file used to store the sector removal
+	// queue.
+	sectorRemovalQueueFile = "sector_removal.dat"
 )
 
 const (

--- a/modules/host/contractmanager/sectorremoval.go
+++ b/modules/host/contractmanager/sectorremoval.go
@@ -1,0 +1,232 @@
+package contractmanager
+
+import (
+	"bufio"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+	"time"
+
+	"gitlab.com/NebulousLabs/errors"
+	"go.sia.tech/siad/crypto"
+	"go.sia.tech/siad/modules"
+)
+
+const removalEntrySize = 20
+
+type (
+	removalEntry struct {
+		ID sectorID
+		// Count refers to the number of references that should be removed from
+		// the contract manager.
+		Count uint64
+		// Offset refers to the position in the persistence file of the entry
+		Offset int64
+	}
+
+	sectorRemovalMap struct {
+		mu          sync.Mutex
+		sectors     map[sectorID]removalEntry
+		entries     int64
+		removalFile *os.File
+
+		cm  *ContractManager
+		wal *writeAheadLog
+	}
+)
+
+// writes the removal entry to disk
+func (srm *sectorRemovalMap) writeRemovalEntry(id sectorID, count uint64, offset int64) error {
+	buf := make([]byte, removalEntrySize)
+	copy(buf[:], id[:])
+	binary.LittleEndian.PutUint64(buf[12:], count)
+	_, err := srm.removalFile.WriteAt(buf, offset)
+	return err
+}
+
+// managedLoad loads the removal queue from disk. Entries with a count of zero
+// and read errors are ignored. The file is compacted while loading.
+func (srm *sectorRemovalMap) managedLoad(path string) (err error) {
+	srm.mu.Lock()
+	defer srm.mu.Unlock()
+
+	srm.removalFile, err = os.OpenFile(path, os.O_RDWR|os.O_CREATE, modules.DefaultFilePerm)
+	if err != nil {
+		return errors.AddContext(err, "unable to open sector removal queue file")
+	}
+	br := bufio.NewReader(srm.removalFile)
+	buf := make([]byte, removalEntrySize)
+	// read each entry from disk. The persistence file is compacted while
+	// reading.
+	for i := int64(0); ; i++ {
+		if _, err := io.ReadFull(br, buf); err == io.EOF || err == io.ErrUnexpectedEOF {
+			break
+		} else if err != nil {
+			return errors.AddContext(err, "error reading sector removal file")
+		}
+
+		entry := removalEntry{
+			Count:  binary.LittleEndian.Uint64(buf[12:]),
+			Offset: srm.entries * removalEntrySize,
+		}
+		copy(entry.ID[:], buf)
+		// skip entries that are no longer needed.
+		if entry.Count == 0 {
+			continue
+		}
+
+		srm.sectors[entry.ID] = entry
+		// if the number of read entries is greater than the number of used
+		// entries overwrite the unused entries.
+		if srm.entries != i {
+			if err := srm.writeRemovalEntry(entry.ID, entry.Count, entry.Offset); err != nil {
+				return errors.AddContext(err, "error updating sector removal entry")
+			}
+		}
+		// increment the number of entries
+		srm.entries++
+	}
+
+	// truncate the file to the last entry written then sync to disk.
+	if err := srm.removalFile.Truncate(int64(srm.entries * removalEntrySize)); err != nil {
+		return errors.AddContext(err, "error truncating sector removal file")
+	} else if err := srm.removalFile.Sync(); err != nil {
+		return errors.AddContext(err, "error syncing sector removal file")
+	}
+	return nil
+}
+
+// removeSectors adds sectors from the map to the WAL
+func (srm *sectorRemovalMap) removeSectors(max int) ([]sectorID, error) {
+	removed := make([]sectorID, 0, max)
+	toRemove := make(map[sectorID]uint64)
+
+	err := func() error {
+		srm.mu.Lock()
+		defer srm.mu.Unlock()
+
+		if len(srm.sectors) == 0 {
+			return nil
+		}
+
+		for id, entry := range srm.sectors {
+			toRemove[id] = entry.Count
+			removed = append(removed, id)
+
+			// update the persistence file
+			if err := srm.writeRemovalEntry(id, 0, entry.Offset); err != nil {
+				return errors.AddContext(err, fmt.Sprintf("error updating sector removal entry %v", id))
+			}
+			// remove the entry from the map
+			delete(srm.sectors, id)
+			if len(toRemove) >= max {
+				break
+			}
+		}
+		return nil
+	}()
+	if err != nil {
+		return nil, err
+	}
+
+	// lock all sectors that are being removed
+	for id := range toRemove {
+		srm.wal.managedLockSector(id)
+		defer srm.wal.managedUnlockSector(id)
+	}
+	return removed, srm.wal.managedRemoveSectors(toRemove)
+}
+
+// threadedRemoveSectors is a gouroutine that periodically removes marked
+// sectors from the host. This reduces lock contention by combining sector
+// removals into one WAL operation and allows other functions to acquire the
+// lock between batches. Like RemoveSectorBatch, this operation is not ACID; the
+// design of the manager will be fixed in v2.
+func (srm *sectorRemovalMap) threadedRemoveSectors() {
+	for {
+		select {
+		case <-srm.cm.tg.StopChan():
+			return
+		case <-time.After(5 * time.Second):
+			err := func() error {
+				err := srm.cm.tg.Add()
+				if err != nil {
+					return errors.AddContext(err, "unable to add remove sector thread")
+				}
+				defer srm.cm.tg.Done()
+
+				// ~3hr per physical TiB
+				if _, err := srm.removeSectors(128); err != nil {
+					srm.cm.log.Println("unable to remove sectors:", err)
+				}
+				return nil
+			}()
+			if err != nil {
+				return
+			}
+		}
+	}
+}
+
+// AddSectors adds a batch of sectors to the removal map. Only the map's lock is
+// required since the actual removal is handled separately by
+// threadedRemoveSectors.
+func (srm *sectorRemovalMap) AddSectors(sectors map[sectorID]uint64) error {
+	srm.mu.Lock()
+	defer srm.mu.Unlock()
+
+	for id, count := range sectors {
+		entry, exists := srm.sectors[id]
+		if !exists {
+			entry = removalEntry{
+				ID:     id,
+				Offset: srm.entries * removalEntrySize,
+			}
+			srm.entries++
+		}
+		entry.Count += count
+		srm.sectors[id] = entry
+		if err := srm.writeRemovalEntry(entry.ID, entry.Count, entry.Offset); err != nil {
+			return errors.AddContext(err, fmt.Sprintf("error updating sector %v removal entry", id))
+		}
+	}
+	return nil
+}
+
+// Close will sync and close the sector removal map.
+func (srm *sectorRemovalMap) Close() error {
+	srm.mu.Lock()
+	defer srm.mu.Unlock()
+	return errors.Compose(srm.removalFile.Sync(), srm.removalFile.Close())
+}
+
+// newSectorRemovalMap initializes a new sector removal queue to batch removal
+// requests over time.
+func newSectorRemovalMap(path string, cm *ContractManager) (*sectorRemovalMap, error) {
+	srm := &sectorRemovalMap{
+		sectors: make(map[sectorID]removalEntry),
+		cm:      cm,
+		wal:     &cm.wal,
+	}
+
+	// load the initial state of the removal queue
+	if err := srm.managedLoad(path); err != nil {
+		return nil, errors.AddContext(err, "unable to load sector removal queue")
+	}
+	// start the removal go routine
+	go srm.threadedRemoveSectors()
+	return srm, nil
+}
+
+// MarkSectorsForRemoval adds sector roots to the removal map. Does not
+// require the WAL lock or sector lock to be held since it is only queuing the
+// removal.
+func (cm *ContractManager) MarkSectorsForRemoval(sectorRoots []crypto.Hash) error {
+	toRemove := make(map[sectorID]uint64)
+	for _, id := range sectorRoots {
+		toRemove[cm.managedSectorID(id)]++
+	}
+	return cm.sectorRemoval.AddSectors(toRemove)
+}

--- a/modules/host/contractmanager/sectorremoval_test.go
+++ b/modules/host/contractmanager/sectorremoval_test.go
@@ -1,0 +1,313 @@
+package contractmanager
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"gitlab.com/NebulousLabs/fastrand"
+	"go.sia.tech/siad/build"
+	"go.sia.tech/siad/crypto"
+	"go.sia.tech/siad/modules"
+)
+
+// TestRemovalQueuePersistence tests that the removal persistence file
+// is written and loaded correctly.
+func TestRemovalQueuePersistence(t *testing.T) {
+	cm, err := New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cm.Close()
+
+	queueFile := filepath.Join(t.TempDir(), sectorRemovalQueueFile)
+	// manually create a new removal queue and initialize the persistence file.
+	sq := &sectorRemovalMap{
+		sectors: make(map[sectorID]removalEntry),
+		cm:      cm,
+		wal:     &cm.wal,
+	}
+	sq.managedLoad(queueFile)
+
+	// generate random sector IDs
+	sectorIDs := make([]sectorID, 1000)
+	for i := range sectorIDs {
+		copy(sectorIDs[i][:], fastrand.Bytes(12))
+	}
+
+	sectorRemovals := make(map[sectorID]uint64)
+	// add half of the sectors to the removal queue
+	for i := range sectorIDs[:500] {
+		sectorRemovals[sectorIDs[i]] = fastrand.Uint64n(1e4) + 1
+	}
+	if err := sq.AddSectors(sectorRemovals); err != nil {
+		t.Fatal(err)
+	}
+
+	// helper func to check the internal state of the queue.
+	checkInternalFields := func(sectors, entries uint64) error {
+		// check that the internal fields are correct
+		if uint64(len(sq.sectors)) != sectors {
+			return fmt.Errorf("unexpected number of sectors in removal queue, expected %v got %v", sectors, len(sq.sectors))
+		} else if uint64(sq.entries) != entries {
+			return fmt.Errorf("unexpected number of entries in removal queue, expected %v got %v", entries, sq.entries)
+		}
+
+		// check that the ids and counters match the expected values
+		for id, count := range sectorRemovals {
+			if sq.sectors[id].Count != count {
+				return fmt.Errorf("unexpected sector removal count for sector %v, expected %v got %v", id, count, sq.sectors[id].Count)
+			}
+		}
+		return nil
+	}
+
+	if err := checkInternalFields(500, 500); err != nil {
+		t.Fatal(err)
+	}
+
+	// close the removal queue to flush it to disk
+	if err := sq.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// check the persisted file size
+	fi, err := os.Stat(queueFile)
+	if err != nil {
+		t.Fatal(err)
+	} else if fi.Size() != 500*removalEntrySize {
+		t.Fatalf("unexpected file size expected %v got %v", 500*removalEntrySize, fi.Size())
+	}
+
+	// reinitialize the queue and load the persistence file from disk
+	sq = &sectorRemovalMap{
+		sectors: make(map[sectorID]removalEntry),
+		cm:      cm,
+		wal:     &cm.wal,
+	}
+	sq.managedLoad(queueFile)
+
+	// check the internal fields are correct
+	if err := checkInternalFields(500, 500); err != nil {
+		t.Fatal(err)
+	}
+
+	// remove half of the sectors from the removal queue
+	removed, err := sq.removeSectors(250)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, id := range removed {
+		delete(sectorRemovals, id)
+	}
+
+	// check that the internal fields are correct. The number of sectors should
+	// change, but the entries should only change when the file is compacted on
+	// reload.
+	if err := checkInternalFields(250, 500); err != nil {
+		t.Fatal(err)
+	}
+
+	// close the removal queue to flush it to disk
+	if err := sq.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// check the persisted file size; the size should not change until the file
+	// is reloaded.
+	fi, err = os.Stat(queueFile)
+	if err != nil {
+		t.Fatal(err)
+	} else if fi.Size() != 500*removalEntrySize {
+		t.Fatalf("unexpected file size expected %v got %v", 500*removalEntrySize, fi.Size())
+	}
+
+	// reload the persistence file and make sure it compacted the file
+	sq = &sectorRemovalMap{
+		sectors: make(map[sectorID]removalEntry),
+		cm:      cm,
+		wal:     &cm.wal,
+	}
+	sq.managedLoad(queueFile)
+
+	// check that the internal fields are correct. The entry and sector counts
+	// should be the new values; the removed sectors should be gone.
+	if err := checkInternalFields(250, 250); err != nil {
+		t.Fatal(err)
+	}
+
+	// check the persistence was properly compacted
+	fi, err = os.Stat(queueFile)
+	if err != nil {
+		t.Fatal(err)
+	} else if fi.Size() != 250*removalEntrySize {
+		t.Fatalf("unexpected file size expected %v got %v", 250*removalEntrySize, fi.Size())
+	} else if err := sq.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// check that the compacted persistence file still loads correctly
+	sq = &sectorRemovalMap{
+		sectors: make(map[sectorID]removalEntry),
+		cm:      cm,
+		wal:     &cm.wal,
+	}
+	sq.managedLoad(queueFile)
+	defer sq.Close()
+
+	// the internal fields should still have the same values
+	if err := checkInternalFields(250, 250); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestMarkSectorsForRemoval(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	dir := t.TempDir()
+	cm, err := New(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		cm.Close()
+	})
+
+	// add a storage folder to the contract manager
+	if err := cm.AddStorageFolder(t.TempDir(), modules.SectorSize*1024); err != nil {
+		t.Fatal(err)
+	}
+
+	// generate random physical sectors
+	sectors := 1024
+	sectorCounts := make(map[crypto.Hash]uint64)
+	buf := make([]byte, modules.SectorSize)
+
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	wg.Add(sectors)
+	sema := make(chan struct{}, 100)
+	for i := 0; i < sectors; i++ {
+		sema <- struct{}{}
+		go func(i int) {
+			defer func() {
+				wg.Done()
+				<-sema
+			}()
+			fastrand.Read(buf)
+			root := crypto.MerkleRoot(buf)
+			if err := cm.AddSector(root, buf); err != nil {
+				panic(err)
+			}
+
+			// add virtual copies of the sector
+			n := fastrand.Uint64n(50)
+			for j := uint64(0); j < n; j++ {
+				if err := cm.AddSector(root, buf); err != nil {
+					panic(err)
+				}
+			}
+
+			// update the counter for the sector
+			mu.Lock()
+			sectorCounts[root] += n + 1
+			mu.Unlock()
+		}(i)
+	}
+
+	wg.Wait()
+
+	// helper function to check the contract manager's internal sector count
+	// matches the expected counts
+	verifySectorCounts := func() error {
+		cm.sectorMu.Lock()
+		defer cm.sectorMu.Unlock()
+
+		for id, count := range sectorCounts {
+			if cm.sectorLocations[cm.managedSectorID(id)].count != count {
+				return fmt.Errorf("unexpected sector count for sector %v, expected %v got %v", id, count, cm.sectorLocations[cm.managedSectorID(id)].count)
+			}
+		}
+		return nil
+	}
+
+	// check the internal sector counts match the expected values
+	if err := verifySectorCounts(); err != nil {
+		t.Fatal(err)
+	}
+
+	// remove half of each sectors virtual sectors
+	var toRemove []crypto.Hash
+	for id, count := range sectorCounts {
+		n := count / 2
+		for i := uint64(0); i < n; i++ {
+			toRemove = append(toRemove, id)
+		}
+		sectorCounts[id] -= n
+	}
+	if err := cm.MarkSectorsForRemoval(toRemove); err != nil {
+		t.Fatal(err)
+	}
+
+	// check the internal sector counts do not match the post-removal values
+	if err := verifySectorCounts(); err == nil {
+		t.Fatal("sector counts should not match immediately after MarkSectorsForRemoval")
+	}
+
+	// wait for the removal sync loop to complete
+	err = build.Retry(10, time.Millisecond*500, func() error {
+		// check the internal sector counts match the expected values
+		if err := verifySectorCounts(); err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// remove the remaining sectors
+	toRemove = toRemove[:0]
+	for id, count := range sectorCounts {
+		for i := uint64(0); i < count; i++ {
+			toRemove = append(toRemove, id)
+		}
+		sectorCounts[id] -= count
+	}
+	if err := cm.MarkSectorsForRemoval(toRemove); err != nil {
+		t.Fatal(err)
+	}
+
+	// immediately close the contract manager so that the removal process is
+	// interrupted
+	cm.Close()
+
+	// reinitialize the contract manager
+	cm, err = New(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// check the internal sector counts do not match the post-removal values
+	if err := verifySectorCounts(); err == nil {
+		t.Fatal("sector counts should not match immediately after MarkSectorsForRemoval")
+	}
+
+	// wait for the removal sync loop to complete
+	err = build.Retry(25, time.Millisecond*500, func() error {
+		// check the internal sector counts match the expected values
+		if err := verifySectorCounts(); err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/modules/host/contractmanager/sectorupdate.go
+++ b/modules/host/contractmanager/sectorupdate.go
@@ -1,15 +1,11 @@
 package contractmanager
 
 import (
-	"encoding/hex"
-	"fmt"
 	"math"
 	"sync"
 	"sync/atomic"
-	"time"
 
 	"gitlab.com/NebulousLabs/errors"
-	"gitlab.com/NebulousLabs/fastrand"
 	"go.sia.tech/siad/build"
 	"go.sia.tech/siad/crypto"
 	"go.sia.tech/siad/modules"
@@ -375,6 +371,113 @@ func (wal *writeAheadLog) managedRemoveSector(id sectorID) error {
 	return nil
 }
 
+// managedRemoveSectors appends changes to the WAL to remove multiple sectors.
+// Individual sector and storage folder errors are ignored.
+func (wal *writeAheadLog) managedRemoveSectors(sectors map[sectorID]uint64) error {
+	wal.mu.Lock()
+	wal.cm.sectorMu.Lock()
+
+	changes := make([]sectorUpdate, 0, len(sectors))
+	for id, count := range sectors {
+		var exists bool
+		location, exists := wal.cm.sectorLocations[id]
+		if !exists {
+			wal.cm.log.Printf("cannot find location for sector %v", id)
+			continue
+		}
+
+		sf, exists := wal.cm.storageFolders[location.storageFolder]
+		if !exists || atomic.LoadUint64(&sf.atomicUnavailable) == 1 {
+			wal.cm.log.Printf("storage folder index %v for sector %v not found", location.storageFolder, id)
+			continue
+		}
+
+		removed := count
+		if location.count < removed {
+			removed = location.count
+		}
+
+		// Inform the WAL of the sector update.
+		location.count -= removed
+		su := sectorUpdate{
+			ID:     id,
+			Count:  location.count,
+			Folder: location.storageFolder,
+			Index:  location.index,
+		}
+		changes = append(changes, su)
+
+		// Update the in-memory representation of the sector.
+		if location.count == 0 {
+			// Delete the sector and mark it as available.
+			delete(wal.cm.sectorLocations, id)
+			sf.availableSectors[id] = location.index
+		} else {
+			// Reduce the sector usage.
+			wal.cm.sectorLocations[id] = location
+		}
+	}
+
+	if len(changes) == 0 {
+		wal.mu.Unlock()
+		wal.cm.sectorMu.Unlock()
+		return nil
+	}
+
+	wal.appendChange(stateChange{
+		SectorUpdates: changes,
+	})
+
+	ch := wal.syncChan
+	wal.mu.Unlock()
+	wal.cm.sectorMu.Unlock()
+
+	// synchronize before updating the metadata or clearing the usage.
+	<-ch
+
+	for _, su := range changes {
+		sf, exists := wal.cm.storageFolders[su.Folder]
+		if !exists || atomic.LoadUint64(&sf.atomicUnavailable) == 1 {
+			wal.cm.log.Printf("commit fail: storage folder index %v for sector %v not found", su.Folder, su.ID)
+			continue
+		}
+
+		// Update the metadata, and the usage.
+		if su.Count != 0 {
+			err := wal.writeSectorMetadata(sf, su)
+			if err != nil {
+				// Revert the previous change.
+				wal.mu.Lock()
+				wal.cm.sectorMu.Lock()
+				su.Count += sectors[su.ID]
+				wal.appendChange(stateChange{
+					SectorUpdates: []sectorUpdate{su},
+				})
+				wal.cm.sectorLocations[su.ID] = sectorLocation{
+					storageFolder: su.Folder,
+					index:         su.Index,
+					count:         su.Count,
+				}
+				wal.cm.sectorMu.Unlock()
+				wal.mu.Unlock()
+				return build.ExtendErr("failed to write sector metadata", err)
+			}
+		}
+
+		// Only update the usage after the sector removal has been committed to
+		// disk entirely. The usage is not updated until after the commit has
+		// completed to prevent the actual sector data from being overwritten in
+		// the event of unclean shutdown.
+		if su.Count == 0 {
+			wal.mu.Lock()
+			sf.clearUsage(su.Index)
+			delete(sf.availableSectors, su.ID)
+			wal.mu.Unlock()
+		}
+	}
+	return nil
+}
+
 // writeSectorMetadata will take a sector update and write the related metadata
 // to disk.
 func (wal *writeAheadLog) writeSectorMetadata(sf *storageFolder, su sectorUpdate) error {
@@ -553,43 +656,4 @@ func (cm *ContractManager) RemoveSector(root crypto.Hash) error {
 	defer cm.wal.managedUnlockSector(id)
 
 	return cm.wal.managedRemoveSector(id)
-}
-
-// RemoveSectorBatch is a non-ACID call to remove a bunch of sectors at once.
-// Necessary for compatibility with old renters.
-//
-// TODO: Make ACID, and definitely improve the performance as well.
-func (cm *ContractManager) RemoveSectorBatch(sectorRoots []crypto.Hash) error {
-	// Prevent shutdown until this function completes.
-	err := cm.tg.Add()
-	if err != nil {
-		return err
-	}
-	defer cm.tg.Done()
-
-	// unique alert id for each call
-	alertID := modules.AlertID("cm-removing-sectors-" + hex.EncodeToString(fastrand.Bytes(12)))
-	start := time.Now()
-	// unregister the alert.
-	defer cm.staticAlerter.UnregisterAlert(alertID)
-
-	// Add each sector in a separate goroutine.
-	var wg sync.WaitGroup
-	// Ensure only 'maxSectorBatchThreads' goroutines are running at a time.
-	semaphore := make(chan struct{}, maxSectorBatchThreads)
-	for i := range sectorRoots {
-		wg.Add(1)
-		semaphore <- struct{}{}
-		go func(i int) {
-			id := cm.managedSectorID(sectorRoots[i])
-			cm.wal.managedLockSector(id)
-			_ = cm.wal.managedRemoveSector(id)
-			cm.wal.managedUnlockSector(id)
-			cm.staticAlerter.RegisterAlert(alertID, fmt.Sprintf("Removed %v/%v sectors in %v", i, len(sectorRoots), time.Since(start)), "", modules.SeverityInfo)
-			<-semaphore
-			wg.Done()
-		}(i)
-	}
-	wg.Wait()
-	return nil
 }

--- a/modules/host/contractmanager/sectorupdate_test.go
+++ b/modules/host/contractmanager/sectorupdate_test.go
@@ -1124,6 +1124,145 @@ func TestRemoveSector(t *testing.T) {
 	}
 }
 
+// TestManagedRemoveSectors tries to remove sectors from the contract manager.
+func TestManagedRemoveSectors(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	t.Parallel()
+	cmt, err := newContractManagerTester("TestManagedRemoveSectors")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cmt.panicClose()
+
+	// Add a storage folder to the contract manager tester.
+	storageFolderDir := filepath.Join(cmt.persistDir, "storageFolderOne")
+	// Create the storage folder dir.
+	err = os.MkdirAll(storageFolderDir, 0700)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = cmt.cm.AddStorageFolder(storageFolderDir, modules.SectorSize*64)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Add two sectors, and then remove one of them.
+	root, data := randSector()
+	err = cmt.cm.AddSector(root, data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root2, data2 := randSector()
+	err = cmt.cm.AddSector(root2, data2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = cmt.cm.wal.managedRemoveSectors(map[sectorID]uint64{cmt.cm.managedSectorID(root2): 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Check that the sector was successfully added.
+	sfs := cmt.cm.StorageFolders()
+	if len(sfs) != 1 {
+		t.Fatal("There should be one storage folder in the contract manager", len(sfs))
+	}
+	if sfs[0].Capacity != sfs[0].CapacityRemaining+modules.SectorSize {
+		t.Error("One sector's worth of capacity should be consumed:", sfs[0].Capacity, sfs[0].CapacityRemaining)
+	}
+	// Break the rules slightly - make the test brittle by looking at the
+	// internals directly to determine that the sector got added to the right
+	// locations, and that the usage information was updated correctly.
+	if len(cmt.cm.sectorLocations) != 1 {
+		t.Fatal("there should be one sector reported in the sectorLocations map")
+	}
+	if len(cmt.cm.storageFolders) != 1 {
+		t.Fatal("storage folder not being reported correctly")
+	}
+	var index uint16
+	for _, sf := range cmt.cm.storageFolders {
+		index = sf.index
+	}
+	for _, sl := range cmt.cm.sectorLocations {
+		if sl.count != 1 {
+			t.Error("Sector location should only be reporting one sector")
+		}
+		if sl.storageFolder != index {
+			t.Error("Sector location is being reported incorrectly - wrong storage folder")
+		}
+		if sl.index > 64 {
+			t.Error("sector index within storage folder also being reported incorrectly")
+		}
+	}
+	// Check the usage.
+	found := false
+	for _, u := range cmt.cm.storageFolders[index].usage {
+		if u != 0 {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("usage field does not seem to have been updated")
+	}
+
+	// Try reloading the contract manager and see if all of the stateful checks
+	// still hold.
+	err = cmt.cm.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmt.cm, err = New(filepath.Join(cmt.persistDir, modules.ContractManagerDir))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Check that the sector was successfully added.
+	sfs = cmt.cm.StorageFolders()
+	if len(sfs) != 1 {
+		t.Fatal("There should be one storage folder in the contract manager", len(sfs))
+	}
+	if sfs[0].Capacity != sfs[0].CapacityRemaining+modules.SectorSize {
+		t.Error("One sector's worth of capacity should be consumed:", (sfs[0].Capacity-sfs[0].CapacityRemaining)/modules.SectorSize)
+	}
+	// Break the rules slightly - make the test brittle by looking at the
+	// internals directly to determine that the sector got added to the right
+	// locations, and that the usage information was updated correctly.
+	if len(cmt.cm.sectorLocations) != 1 {
+		t.Fatal("there should be one sector reported in the sectorLocations map:", len(cmt.cm.sectorLocations))
+	}
+	if len(cmt.cm.storageFolders) != 1 {
+		t.Fatal("storage folder not being reported correctly")
+	}
+	for _, sf := range cmt.cm.storageFolders {
+		index = sf.index
+	}
+	for _, sl := range cmt.cm.sectorLocations {
+		if sl.count != 1 {
+			t.Error("Sector location should only be reporting one sector:", sl.count)
+		}
+		if sl.storageFolder != index {
+			t.Error("Sector location is being reported incorrectly - wrong storage folder", sl.storageFolder, index)
+		}
+		if sl.index > 64 {
+			t.Error("sector index within storage folder also being reported incorrectly")
+		}
+	}
+	// Check the usage.
+	found = false
+	for _, u := range cmt.cm.storageFolders[index].usage {
+		if u != 0 {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("usage field does not seem to have been updated")
+	}
+}
+
 // TestRemoveSectorVirtual tries to remove a virtual sector from the contract
 // manager.
 func TestRemoveSectorVirtual(t *testing.T) {

--- a/modules/host/storageobligations.go
+++ b/modules/host/storageobligations.go
@@ -984,13 +984,9 @@ func (h *Host) PruneStaleStorageObligations() error {
 // removeStorageObligation will remove a storage obligation from the host,
 // either due to failure or success.
 func (h *Host) removeStorageObligation(so storageObligation, sos storageObligationStatus) error {
-	// Error is not checked, we want to call remove on every sector even if
-	// there are problems - disk health information will be updated.
-	start := time.Now()
-	h.log.Printf("Removing %v sectors for contract %v", len(so.SectorRoots), so.id())
-	_ = h.RemoveSectorBatch(so.SectorRoots)
-	h.log.Printf("Removing %v sectors for contract %v finished in %v", len(so.SectorRoots), so.id(),
-		time.Since(start))
+	if err := h.MarkSectorsForRemoval(so.SectorRoots); err != nil {
+		h.log.Printf("contract %s, error marking sectors for removal: %v", so.id(), err)
+	}
 
 	// Update the host revenue metrics based on the status of the obligation.
 	if sos == obligationUnresolved {

--- a/modules/storagemanager.go
+++ b/modules/storagemanager.go
@@ -99,10 +99,11 @@ type (
 		// auto-expiry information for that sector can be properly updated.
 		RemoveSector(sectorRoot crypto.Hash) error
 
-		// RemoveSectorBatch is a non-ACID performance optimization to remove a
-		// ton of sectors from the storage manager all at once. This is
-		// necessary when clearing out an entire contract from the host.
-		RemoveSectorBatch(sectorRoots []crypto.Hash) error
+		// MarkSectorsForRemoval is a non-ACID performance optimization to
+		// remove a ton of sectors from the host. Works around lockups in the
+		// WAL by batching sectors to be removed over a period of time instead
+		// of all at once.
+		MarkSectorsForRemoval(sectorRoots []crypto.Hash) error
 
 		// RemoveStorageFolder will remove a storage folder from the manager.
 		// All storage on the folder will be moved to other storage folders,


### PR DESCRIPTION
Adds a sector removal map to the contract manager for removing large amounts of sectors. `RemoveSectorBatch` causes lock contention for long periods when removing large (2TB+) contracts and contracts with many virtual sectors due to individual sector locking/unlocking. When queueing sectors, only the map's mutex needs to be locked. When removed, physical and virtual sectors are batched into a single WAL operation. Each physical TiB takes around 3 hours to clear with the additional delay. Under ideal conditions, `RemoveSectorBatch` takes approximately 26 minutes per TiB due to a 500ms delay in the WAL sync; however, with lock contention, users have reported contracts with a few TiB taking days to remove.

The persistence file saves 20 bytes per physical sector, the 12-byte sector ID and an 8-byte counter. When a sector is queued, the counter is incremented. After removal, the counter is set to 0. All sectors with 0 counts are compacted when the host is reloaded to save storage space. 1TiB of physical sectors will be 5MiB on disk. 