### PR TITLE
Fix contract manager data race

### DIFF
--- a/modules/host/contractmanager/sectorremoval_test.go
+++ b/modules/host/contractmanager/sectorremoval_test.go
@@ -193,6 +193,7 @@ func TestMarkSectorsForRemoval(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 
 	dir := t.TempDir()
 	cm, err := New(dir)


### PR DESCRIPTION
Adds missing locks to `ContractManager.sectorMu` around calls to `storageFolder.setUsage` and `storageFolder.clearUsage`. Fixes #120 @ChrisSchinnerl