### PR TITLE
Remove need for /api prefix in api routes

### DIFF
--- a/api/explored/server.go
+++ b/api/explored/server.go
@@ -106,13 +106,13 @@ func NewServer(cm ChainManager, s Syncer, tp TransactionPool) http.Handler {
 	}
 	mux := httprouter.New()
 
-	mux.GET("/api/txpool/transactions", srv.txpoolTransactionsHandler)
-	mux.POST("/api/txpool/broadcast", srv.txpoolBroadcastHandler)
+	mux.GET("/txpool/transactions", srv.txpoolTransactionsHandler)
+	mux.POST("/txpool/broadcast", srv.txpoolBroadcastHandler)
 
-	mux.GET("/api/syncer/peers", srv.syncerPeersHandler)
-	mux.POST("/api/syncer/connect", srv.syncerConnectHandler)
+	mux.GET("/syncer/peers", srv.syncerPeersHandler)
+	mux.POST("/syncer/connect", srv.syncerConnectHandler)
 
-	mux.GET("/api/consensus/tip", srv.consensusTipHandler)
+	mux.GET("/consensus/tip", srv.consensusTipHandler)
 
 	return mux
 }

--- a/api/renterd/server.go
+++ b/api/renterd/server.go
@@ -289,18 +289,18 @@ func NewServer(cm ChainManager, s Syncer, w *walletutil.TestingWallet, tp Transa
 	}
 	mux := httprouter.New()
 
-	mux.GET("/api/wallet/balance", srv.walletBalanceHandler)
-	mux.GET("/api/wallet/address", srv.walletAddressHandler)
-	mux.GET("/api/wallet/transactions", srv.walletTransactionsHandler)
+	mux.GET("/wallet/balance", srv.walletBalanceHandler)
+	mux.GET("/wallet/address", srv.walletAddressHandler)
+	mux.GET("/wallet/transactions", srv.walletTransactionsHandler)
 
-	mux.GET("/api/syncer/peers", srv.syncerPeersHandler)
-	mux.POST("/api/syncer/connect", srv.syncerConnectHandler)
+	mux.GET("/syncer/peers", srv.syncerPeersHandler)
+	mux.POST("/syncer/connect", srv.syncerConnectHandler)
 
-	mux.POST("/api/rhp/scan", srv.rhpScanHandler)
-	mux.POST("/api/rhp/form", srv.rhpFormHandler)
-	mux.POST("/api/rhp/renew", srv.rhpRenewHandler)
-	mux.POST("/api/rhp/read", srv.rhpReadHandler)
-	mux.POST("/api/rhp/append", srv.rhpAppendHandler)
+	mux.POST("/rhp/scan", srv.rhpScanHandler)
+	mux.POST("/rhp/form", srv.rhpFormHandler)
+	mux.POST("/rhp/renew", srv.rhpRenewHandler)
+	mux.POST("/rhp/read", srv.rhpReadHandler)
+	mux.POST("/rhp/append", srv.rhpAppendHandler)
 
 	return mux
 }

--- a/api/siad/server.go
+++ b/api/siad/server.go
@@ -259,23 +259,23 @@ func NewServer(cm ChainManager, s Syncer, w WalletStore, tp TransactionPool) htt
 	}
 	mux := httprouter.New()
 
-	mux.GET("/api/consensus/tip", srv.consensusTipHandler)
-	mux.GET("/api/consensus/state/:index", srv.consensusStateHandler)
-	mux.POST("/api/consensus/broadcast", srv.consensusBroadcastHandler)
+	mux.GET("/consensus/tip", srv.consensusTipHandler)
+	mux.GET("/consensus/state/:index", srv.consensusStateHandler)
+	mux.POST("/consensus/broadcast", srv.consensusBroadcastHandler)
 
-	mux.GET("/api/wallet/balance", srv.walletBalanceHandler)
-	mux.GET("/api/wallet/seedindex", srv.walletSeedIndexHandler)
-	mux.POST("/api/wallet/address/:addr", srv.walletAddressHandlerPOST)
-	mux.GET("/api/wallet/address/:addr", srv.walletAddressHandlerGET)
-	mux.GET("/api/wallet/addresses", srv.walletAddressesHandler)
-	mux.GET("/api/wallet/transactions", srv.walletTransactionsHandler)
-	mux.GET("/api/wallet/utxos", srv.walletUTXOsHandler)
+	mux.GET("/wallet/balance", srv.walletBalanceHandler)
+	mux.GET("/wallet/seedindex", srv.walletSeedIndexHandler)
+	mux.POST("/wallet/address/:addr", srv.walletAddressHandlerPOST)
+	mux.GET("/wallet/address/:addr", srv.walletAddressHandlerGET)
+	mux.GET("/wallet/addresses", srv.walletAddressesHandler)
+	mux.GET("/wallet/transactions", srv.walletTransactionsHandler)
+	mux.GET("/wallet/utxos", srv.walletUTXOsHandler)
 
-	mux.GET("/api/txpool/transactions", srv.txpoolTransactionsHandler)
-	mux.POST("/api/txpool/broadcast", srv.txpoolBroadcastHandler)
+	mux.GET("/txpool/transactions", srv.txpoolTransactionsHandler)
+	mux.POST("/txpool/broadcast", srv.txpoolBroadcastHandler)
 
-	mux.GET("/api/syncer/peers", srv.syncerPeersHandler)
-	mux.POST("/api/syncer/connect", srv.syncerConnectHandler)
+	mux.GET("/syncer/peers", srv.syncerPeersHandler)
+	mux.POST("/syncer/connect", srv.syncerConnectHandler)
 
 	return mux
 }

--- a/cmd/renterd/web.go
+++ b/cmd/renterd/web.go
@@ -41,6 +41,7 @@ func startWeb(l net.Listener, node *node, password string) error {
 	web := createUIHandler()
 	return http.Serve(l, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasPrefix(r.URL.Path, "/api") {
+			r.URL.Path = strings.TrimPrefix(r.URL.Path, "/api")
 			api.ServeHTTP(w, r)
 			return
 		}

--- a/cmd/siad/web.go
+++ b/cmd/siad/web.go
@@ -41,6 +41,7 @@ func startWeb(l net.Listener, node *node, password string) error {
 	web := createUIHandler()
 	return http.Serve(l, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasPrefix(r.URL.Path, "/api") {
+			r.URL.Path = strings.TrimPrefix(r.URL.Path, "/api")
 			api.ServeHTTP(w, r)
 			return
 		}


### PR DESCRIPTION
This PR allows us to declare the API routes without the /api prefix but serve them under that route in the various binaries (siad, renterd, explored).