### PR TITLE
Extend subscription rhp with ability to subscribe by registry entry id

### DIFF
--- a/modules/host/host_test.go
+++ b/modules/host/host_test.go
@@ -976,11 +976,37 @@ func (p *renterHostPair) SubcribeToRV(stream siamux.Stream, pt *modules.RPCPrice
 	return rv, nil
 }
 
+// SubscribeToRVByRID subscribes to the given publickey/tweak pair.
+func (p *renterHostPair) SubcribeToRVByRID(stream siamux.Stream, pt *modules.RPCPriceTable, rid modules.RegistryEntryID) (*modules.SignedRegistryValue, error) {
+	rvs, err := modules.RPCSubscribeToRVsByRID(stream, []modules.RPCRegistrySubscriptionByRIDRequest{{
+		EntryID: rid,
+	}})
+	if err != nil {
+		return nil, err
+	}
+
+	// Check response.
+	var rv *modules.SignedRegistryValue
+	if len(rvs) > 1 {
+		build.Critical("more responses than subscribed to values")
+	} else if len(rvs) == 1 {
+		rv = &rvs[0].Entry
+	}
+	return rv, nil
+}
+
 // UnsubscribeFromRV unsubscribes from the given publickey/tweak pair.
 func (p *renterHostPair) UnsubcribeFromRV(stream siamux.Stream, pt *modules.RPCPriceTable, pubkey types.SiaPublicKey, tweak crypto.Hash) error {
 	return modules.RPCUnsubscribeFromRVs(stream, []modules.RPCRegistrySubscriptionRequest{{
 		PubKey: pubkey,
 		Tweak:  tweak,
+	}})
+}
+
+// UnsubscribeFromRVByRID unsubscribes from the given publickey/tweak pair.
+func (p *renterHostPair) UnsubcribeFromRVByRID(stream siamux.Stream, pt *modules.RPCPriceTable, rid modules.RegistryEntryID) error {
+	return modules.RPCUnsubscribeFromRVsByRID(stream, []modules.RPCRegistrySubscriptionByRIDRequest{{
+		EntryID: rid,
 	}})
 }
 

--- a/modules/host/rpcsubscribe.go
+++ b/modules/host/rpcsubscribe.go
@@ -138,9 +138,53 @@ func (h *Host) managedHandleSubscribeRequest(info *subscriptionInfo, pt *modules
 		}
 		rvs = append(rvs, rv)
 	}
+	if err := h.managedHandleFinalizeSubscribeRequest(info, pt, ids, uint64(len(rvs))); err != nil {
+		return err
+	}
 
+	// Write initial values to the stream.
+	return errors.AddContext(modules.RPCWrite(stream, rvs), "failed to write initial values to stream")
+}
+
+// managedHandleSubscribeByRIDRequest handles a new subscription.
+func (h *Host) managedHandleSubscribeByRIDRequest(info *subscriptionInfo, pt *modules.RPCPriceTable) error {
+	stream := info.staticStream
+
+	// Read the requests.
+	var rsrs []modules.RPCRegistrySubscriptionByRIDRequest
+	err := modules.RPCRead(stream, &rsrs)
+	if err != nil {
+		return errors.AddContext(err, "failed to read subscription request")
+	}
+
+	// Send initial values.
+	ids := make([]modules.RegistryEntryID, 0, len(rsrs))
+	rvs := make([]modules.RPCRegistrySubscriptionNotificationEntryUpdate, 0, len(ids))
+	for _, rsr := range rsrs {
+		ids = append(ids, rsr.EntryID)
+		pk, rv, found := h.staticRegistry.Get(rsr.EntryID)
+		if !found {
+			continue
+		}
+		rvs = append(rvs, modules.RPCRegistrySubscriptionNotificationEntryUpdate{
+			Entry:  rv,
+			PubKey: pk,
+		})
+	}
+	if err := h.managedHandleFinalizeSubscribeRequest(info, pt, ids, uint64(len(rvs))); err != nil {
+		return err
+	}
+
+	// Write initial values to the stream.
+	return errors.AddContext(modules.RPCWrite(stream, rvs), "failed to write initial values to stream")
+}
+
+// managedHandleFinalizeSubscribeRequest finalizes a SubscribeRequest by
+// computing its cost, withdrawing it from the budget and adding the
+// subscriptions.
+func (h *Host) managedHandleFinalizeSubscribeRequest(info *subscriptionInfo, pt *modules.RPCPriceTable, ids []modules.RegistryEntryID, numResponses uint64) error {
 	// Compute the subscription cost.
-	cost := modules.MDMSubscribeCost(pt, uint64(len(rvs)), uint64(len(ids)))
+	cost := modules.MDMSubscribeCost(pt, numResponses, uint64(len(ids)))
 
 	// Withdraw from the budget.
 	if !info.staticBudget.Withdraw(cost) {
@@ -150,11 +194,6 @@ func (h *Host) managedHandleSubscribeRequest(info *subscriptionInfo, pt *modules
 	// Add the subscriptions.
 	h.staticRegistrySubscriptions.AddSubscriptions(info, ids...)
 
-	// Write initial values to the stream.
-	err = modules.RPCWrite(stream, rvs)
-	if err != nil {
-		return errors.AddContext(err, "failed to write initial values to stream")
-	}
 	return nil
 }
 
@@ -169,7 +208,7 @@ func (h *Host) managedHandleStopSubscription(info *subscriptionInfo) error {
 }
 
 // managedHandleUnsubscribeRequest handles a request to unsubscribe.
-func (h *Host) managedHandleUnsubscribeRequest(info *subscriptionInfo, pt *modules.RPCPriceTable) error {
+func (h *Host) managedHandleUnsubscribeRequest(info *subscriptionInfo) error {
 	stream := info.staticStream
 
 	// Read the requests.
@@ -188,6 +227,39 @@ func (h *Host) managedHandleUnsubscribeRequest(info *subscriptionInfo, pt *modul
 
 	// Respond with "OK".
 	err = modules.RPCWrite(stream, modules.RPCRegistrySubscriptionNotificationType{
+		Type: modules.SubscriptionResponseUnsubscribeSuccess,
+	})
+	return errors.AddContext(err, "failed to signal successfully unsubscribing from entries")
+}
+
+// managedHandleUnsubscribeByRIDRequest handles a request to unsubscribe.
+func (h *Host) managedHandleUnsubscribeByRIDRequest(info *subscriptionInfo) error {
+	stream := info.staticStream
+
+	// Read the requests.
+	var rsrs []modules.RPCRegistrySubscriptionByRIDRequest
+	err := modules.RPCRead(stream, &rsrs)
+	if err != nil {
+		return errors.AddContext(err, "failed to read subscription requests")
+	}
+	ids := make([]modules.RegistryEntryID, 0, len(rsrs))
+	for _, rsr := range rsrs {
+		ids = append(ids, rsr.EntryID)
+	}
+	return h.managedHandleFinalizeUnsubscribeRequest(info, ids)
+}
+
+// managedHandleFinalizeUnsubscribeRequest finalizes unsubscribing from one or
+// more registry entries by removing them from the subscriptions and responding
+// with an 'OK'.
+func (h *Host) managedHandleFinalizeUnsubscribeRequest(info *subscriptionInfo, ids []modules.RegistryEntryID) error {
+	stream := info.staticStream
+
+	// Remove the subscription.
+	h.staticRegistrySubscriptions.RemoveSubscriptions(info, ids)
+
+	// Respond with "OK".
+	err := modules.RPCWrite(stream, modules.RPCRegistrySubscriptionNotificationType{
 		Type: modules.SubscriptionResponseUnsubscribeSuccess,
 	})
 	return errors.AddContext(err, "failed to signal successfully unsubscribing from entries")
@@ -432,7 +504,11 @@ func (h *Host) managedRPCRegistrySubscribe(stream siamux.Stream) (_ afterCloseFn
 		case modules.SubscriptionRequestSubscribe:
 			err = h.managedHandleSubscribeRequest(info, pt)
 		case modules.SubscriptionRequestUnsubscribe:
-			err = h.managedHandleUnsubscribeRequest(info, pt)
+			err = h.managedHandleUnsubscribeRequest(info)
+		case modules.SubscriptionRequestSubscribeRID:
+			err = h.managedHandleSubscribeByRIDRequest(info, pt)
+		case modules.SubscriptionRequestUnsubscribeRID:
+			err = h.managedHandleUnsubscribeByRIDRequest(info)
 		case modules.SubscriptionRequestExtend:
 			pt, deadline, err = h.managedHandleExtendSubscriptionRequest(stream, deadline, info, bandwidthLimit)
 		case modules.SubscriptionRequestPrepay:

--- a/modules/host/rpcsubscribe.go
+++ b/modules/host/rpcsubscribe.go
@@ -221,15 +221,7 @@ func (h *Host) managedHandleUnsubscribeRequest(info *subscriptionInfo) error {
 	for _, rsr := range rsrs {
 		ids = append(ids, modules.DeriveRegistryEntryID(rsr.PubKey, rsr.Tweak))
 	}
-
-	// Remove the subscription.
-	h.staticRegistrySubscriptions.RemoveSubscriptions(info, ids)
-
-	// Respond with "OK".
-	err = modules.RPCWrite(stream, modules.RPCRegistrySubscriptionNotificationType{
-		Type: modules.SubscriptionResponseUnsubscribeSuccess,
-	})
-	return errors.AddContext(err, "failed to signal successfully unsubscribing from entries")
+	return h.managedHandleFinalizeUnsubscribeRequest(info, ids)
 }
 
 // managedHandleUnsubscribeByRIDRequest handles a request to unsubscribe.

--- a/modules/renter/workersubscription_test.go
+++ b/modules/renter/workersubscription_test.go
@@ -1299,10 +1299,10 @@ func TestThreadedSubscriptionLoop(t *testing.T) {
 	}
 }
 
-// TestSubscribeUnsubsribeByRID tests the subscription helper methods against
+// TestSubscribeUnsubscribeByRID tests the subscription helper methods against
 // the worker tester. They are already unit-tested against a host in
 // rpcsubscribe_test.go but better safe than sorry.
-func TestSubscribeUnsubsribeByRID(t *testing.T) {
+func TestSubscribeUnsubscribeByRID(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}

--- a/modules/rpc.go
+++ b/modules/rpc.go
@@ -33,6 +33,8 @@ const (
 	SubscriptionRequestExtend
 	SubscriptionRequestPrepay
 	SubscriptionRequestStop
+	SubscriptionRequestSubscribeRID
+	SubscriptionRequestUnsubscribeRID
 )
 
 // Subcription response related enum.
@@ -280,6 +282,18 @@ type (
 	RPCRegistrySubscriptionRequest struct {
 		PubKey types.SiaPublicKey
 		Tweak  crypto.Hash
+
+		// Ratelimit in milliseconds. This is not used yet but carved out to
+		// avoid a breaking protocol change later on. The idea is that for every
+		// subscribed entry, a ratelimit can be specified to avoid spam and
+		// reduce cost.
+		Ratelimit uint32
+	}
+
+	// RPCRegistrySubscriptionByRIDRequest is a request to either add or
+	// remove a subscription.
+	RPCRegistrySubscriptionByRIDRequest struct {
+		EntryID RegistryEntryID
 
 		// Ratelimit in milliseconds. This is not used yet but carved out to
 		// avoid a breaking protocol change later on. The idea is that for every


### PR DESCRIPTION
This MR adds another type of request to the subscription rhp to allow for subscribing only via registry ID.
The result is the same as for regular subscriptions except for the initial values we send to the client after subscribing. These now contain the public key to allow the client to verify that the responses belong to the values they requested.