### PR TITLE
Add HostDB API endpoints

### DIFF
--- a/api/renterd/api.go
+++ b/api/renterd/api.go
@@ -3,7 +3,6 @@ package renterd
 import (
 	"go.sia.tech/core/net/rhp"
 	"go.sia.tech/core/types"
-	"go.sia.tech/siad/v2/hostdb"
 )
 
 // WalletBalanceResponse is the response to /wallet/balance.
@@ -95,9 +94,4 @@ type RHPAppendResponse struct {
 // A HostDBScoreRequest sets the score of a host.
 type HostDBScoreRequest struct {
 	Score float64 `json:"score"`
-}
-
-// A HostDBInteractionRequest records interactions with a host.
-type HostDBInteractionRequest struct {
-	Interactions []hostdb.Interaction `json:"interaction"`
 }

--- a/api/renterd/api.go
+++ b/api/renterd/api.go
@@ -3,6 +3,7 @@ package renterd
 import (
 	"go.sia.tech/core/net/rhp"
 	"go.sia.tech/core/types"
+	"go.sia.tech/siad/v2/hostdb"
 )
 
 // WalletBalanceResponse is the response to /wallet/balance.
@@ -89,4 +90,14 @@ type RHPAppendRequest struct {
 // root of the appended sector.
 type RHPAppendResponse struct {
 	SectorRoot types.Hash256 `json:"sectorRoot"`
+}
+
+// A HostDBScoreRequest sets the score of a host.
+type HostDBScoreRequest struct {
+	Score float64 `json:"score"`
+}
+
+// A HostDBInteractionRequest records an interaction with a host.
+type HostDBInteractionRequest struct {
+	Interaction hostdb.Interaction `json:"interaction"`
 }

--- a/api/renterd/api.go
+++ b/api/renterd/api.go
@@ -97,7 +97,7 @@ type HostDBScoreRequest struct {
 	Score float64 `json:"score"`
 }
 
-// A HostDBInteractionRequest records an interaction with a host.
+// A HostDBInteractionRequest records interactions with a host.
 type HostDBInteractionRequest struct {
-	Interaction hostdb.Interaction `json:"interaction"`
+	Interactions []hostdb.Interaction `json:"interaction"`
 }

--- a/api/renterd/client.go
+++ b/api/renterd/client.go
@@ -14,6 +14,7 @@ import (
 	"go.sia.tech/core/net/rhp"
 	"go.sia.tech/core/types"
 	"go.sia.tech/siad/v2/api"
+	"go.sia.tech/siad/v2/hostdb"
 	"go.sia.tech/siad/v2/wallet"
 )
 
@@ -119,6 +120,30 @@ func (c *Client) RHPAppend(rar RHPAppendRequest, sector *[rhp.SectorSize]byte) (
 		return RHPAppendResponse{}, errors.New(string(err))
 	}
 	err = json.NewDecoder(r.Body).Decode(&resp)
+	return
+}
+
+// HostDBHosts gets a list of hosts in the host DB.
+func (c *Client) HostDBHosts() (resp []hostdb.Host, err error) {
+	err = c.c.Get("/api/hostdb", &resp)
+	return
+}
+
+// HostDBHost gets information about a given host.
+func (c *Client) HostDBHost(hostKey types.PublicKey) (resp []hostdb.Host, err error) {
+	err = c.c.Get(fmt.Sprintf("/api/hostdb/%s", hostKey), &resp)
+	return
+}
+
+// HostDBScore assigns a score to a given host.
+func (c *Client) HostDBScore(hostKey types.PublicKey, score float64) (err error) {
+	err = c.c.Put(fmt.Sprintf("/api/hostdb/%s/score", hostKey), HostDBScoreRequest{score})
+	return
+}
+
+// HostDBInteraction records an interaction with a given host.
+func (c *Client) HostDBInteraction(hostKey types.PublicKey, interaction hostdb.Interaction) (err error) {
+	err = c.c.Put(fmt.Sprintf("/api/hostdb/%s/interaction", hostKey), HostDBInteractionRequest{interaction})
 	return
 }
 

--- a/api/renterd/client.go
+++ b/api/renterd/client.go
@@ -143,7 +143,7 @@ func (c *Client) HostDBScore(hostKey types.PublicKey, score float64) (err error)
 
 // HostDBInteractions records interactions with a given host.
 func (c *Client) HostDBInteractions(hostKey types.PublicKey, interactions []hostdb.Interaction) (err error) {
-	err = c.c.Put(fmt.Sprintf("/api/hostdb/%s/interactions", hostKey), HostDBInteractionRequest{interactions})
+	err = c.c.Put(fmt.Sprintf("/api/hostdb/%s/interactions", hostKey), interactions)
 	return
 }
 

--- a/api/renterd/client.go
+++ b/api/renterd/client.go
@@ -141,9 +141,9 @@ func (c *Client) HostDBScore(hostKey types.PublicKey, score float64) (err error)
 	return
 }
 
-// HostDBInteraction records an interaction with a given host.
-func (c *Client) HostDBInteraction(hostKey types.PublicKey, interaction hostdb.Interaction) (err error) {
-	err = c.c.Put(fmt.Sprintf("/api/hostdb/%s/interaction", hostKey), HostDBInteractionRequest{interaction})
+// HostDBInteractions records interactions with a given host.
+func (c *Client) HostDBInteractions(hostKey types.PublicKey, interactions []hostdb.Interaction) (err error) {
+	err = c.c.Put(fmt.Sprintf("/api/hostdb/%s/interactions", hostKey), HostDBInteractionRequest{interactions})
 	return
 }
 

--- a/api/renterd/server.go
+++ b/api/renterd/server.go
@@ -332,13 +332,13 @@ func (s *server) hostdbHostInteractionsHandler(w http.ResponseWriter, req *http.
 		return
 	}
 
-	var hsr HostDBInteractionRequest
-	if err := json.NewDecoder(req.Body).Decode(&hsr); err != nil {
+	var interactions []hostdb.Interaction
+	if err := json.NewDecoder(req.Body).Decode(&interactions); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
-	for _, interaction := range hsr.Interactions {
+	for _, interaction := range interactions {
 		if err := s.hdb.RecordInteraction(pk, interaction); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/api/renterd/server.go
+++ b/api/renterd/server.go
@@ -58,7 +58,7 @@ type (
 		RecordInteraction(hostKey types.PublicKey, hi hostdb.Interaction) error
 		SetScore(hostKey types.PublicKey, score float64) error
 		SelectHosts(n int, filter func(hostdb.Host) bool) []hostdb.Host
-		Host(hostKey types.PublicKey) hostdb.Host
+		Host(hostKey types.PublicKey) (hostdb.Host, error)
 	}
 )
 
@@ -303,7 +303,12 @@ func (s *server) hostdbHostHandler(w http.ResponseWriter, req *http.Request, p h
 		return
 	}
 
-	api.WriteJSON(w, s.hdb.Host(pk))
+	host, err := s.hdb.Host(pk)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	api.WriteJSON(w, host)
 }
 
 func (s *server) hostdbHostScoreHandler(w http.ResponseWriter, req *http.Request, p httprouter.Params) {

--- a/api/renterd/server.go
+++ b/api/renterd/server.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"strconv"
 	"time"
@@ -13,6 +14,7 @@ import (
 	"go.sia.tech/core/net/rhp"
 	"go.sia.tech/core/types"
 	"go.sia.tech/siad/v2/api"
+	"go.sia.tech/siad/v2/hostdb"
 	"go.sia.tech/siad/v2/internal/walletutil"
 	"go.sia.tech/siad/v2/renter"
 	"go.sia.tech/siad/v2/wallet"
@@ -50,13 +52,22 @@ type (
 	ChainManager interface {
 		TipState() consensus.State
 	}
+
+	// A HostDB stores host information.
+	HostDB interface {
+		RecordInteraction(hostKey types.PublicKey, hi hostdb.Interaction) error
+		SetScore(hostKey types.PublicKey, score float64) error
+		SelectHosts(n int, filter func(hostdb.Host) bool) []hostdb.Host
+		Host(hostKey types.PublicKey) hostdb.Host
+	}
 )
 
 type server struct {
-	w  Wallet
-	s  Syncer
-	cm ChainManager
-	tp TransactionPool
+	w   Wallet
+	s   Syncer
+	cm  ChainManager
+	tp  TransactionPool
+	hdb HostDB
 }
 
 func (s *server) walletBalanceHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
@@ -279,13 +290,68 @@ func (s *server) rhpAppendHandler(w http.ResponseWriter, req *http.Request, _ ht
 	api.WriteJSON(w, RHPAppendResponse{root})
 }
 
+func (s *server) hostdbHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
+	api.WriteJSON(w, s.hdb.SelectHosts(math.MaxInt64, func(hostdb.Host) bool {
+		return true
+	}))
+}
+
+func (s *server) hostdbHostHandler(w http.ResponseWriter, req *http.Request, p httprouter.Params) {
+	var pk types.PublicKey
+	if err := pk.UnmarshalText([]byte(p.ByName("pk"))); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	api.WriteJSON(w, s.hdb.Host(pk))
+}
+
+func (s *server) hostdbHostScoreHandler(w http.ResponseWriter, req *http.Request, p httprouter.Params) {
+	var pk types.PublicKey
+	if err := pk.UnmarshalText([]byte(p.ByName("pk"))); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	var hsr HostDBScoreRequest
+	if err := json.NewDecoder(req.Body).Decode(&hsr); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	if err := s.hdb.SetScore(pk, hsr.Score); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+}
+
+func (s *server) hostdbHostInteractionHandler(w http.ResponseWriter, req *http.Request, p httprouter.Params) {
+	var pk types.PublicKey
+	if err := pk.UnmarshalText([]byte(p.ByName("pk"))); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	var hsr HostDBInteractionRequest
+	if err := json.NewDecoder(req.Body).Decode(&hsr); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	if err := s.hdb.RecordInteraction(pk, hsr.Interaction); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+}
+
 // NewServer returns an HTTP handler that serves the renterd API.
-func NewServer(cm ChainManager, s Syncer, w *walletutil.TestingWallet, tp TransactionPool) http.Handler {
+func NewServer(cm ChainManager, s Syncer, w *walletutil.TestingWallet, tp TransactionPool, hdb HostDB) http.Handler {
 	srv := server{
-		cm: cm,
-		s:  s,
-		w:  w,
-		tp: tp,
+		cm:  cm,
+		s:   s,
+		w:   w,
+		tp:  tp,
+		hdb: hdb,
 	}
 	mux := httprouter.New()
 
@@ -301,6 +367,11 @@ func NewServer(cm ChainManager, s Syncer, w *walletutil.TestingWallet, tp Transa
 	mux.POST("/rhp/renew", srv.rhpRenewHandler)
 	mux.POST("/rhp/read", srv.rhpReadHandler)
 	mux.POST("/rhp/append", srv.rhpAppendHandler)
+
+	mux.GET("/hostdb", srv.hostdbHandler)
+	mux.GET("/hostdb/:pk", srv.hostdbHostHandler)
+	mux.PUT("/hostdb/:pk/score", srv.hostdbHostScoreHandler)
+	mux.POST("/hostdb/:pk/interaction", srv.hostdbHostInteractionHandler)
 
 	return mux
 }

--- a/api/renterd/server.go
+++ b/api/renterd/server.go
@@ -325,7 +325,7 @@ func (s *server) hostdbHostScoreHandler(w http.ResponseWriter, req *http.Request
 	}
 }
 
-func (s *server) hostdbHostInteractionHandler(w http.ResponseWriter, req *http.Request, p httprouter.Params) {
+func (s *server) hostdbHostInteractionsHandler(w http.ResponseWriter, req *http.Request, p httprouter.Params) {
 	var pk types.PublicKey
 	if err := pk.UnmarshalText([]byte(p.ByName("pk"))); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
@@ -338,9 +338,11 @@ func (s *server) hostdbHostInteractionHandler(w http.ResponseWriter, req *http.R
 		return
 	}
 
-	if err := s.hdb.RecordInteraction(pk, hsr.Interaction); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
+	for _, interaction := range hsr.Interactions {
+		if err := s.hdb.RecordInteraction(pk, interaction); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 	}
 }
 
@@ -371,7 +373,7 @@ func NewServer(cm ChainManager, s Syncer, w *walletutil.TestingWallet, tp Transa
 	mux.GET("/hostdb", srv.hostdbHandler)
 	mux.GET("/hostdb/:pk", srv.hostdbHostHandler)
 	mux.PUT("/hostdb/:pk/score", srv.hostdbHostScoreHandler)
-	mux.POST("/hostdb/:pk/interaction", srv.hostdbHostInteractionHandler)
+	mux.POST("/hostdb/:pk/interactions", srv.hostdbHostInteractionsHandler)
 
 	return mux
 }

--- a/cmd/renterd/web.go
+++ b/cmd/renterd/web.go
@@ -36,7 +36,7 @@ func createUIHandler() http.Handler {
 }
 
 func startWeb(l net.Listener, node *node, password string) error {
-	renter := renterd.NewServer(node.c, node.s, node.w, node.tp)
+	renter := renterd.NewServer(node.c, node.s, node.w, node.tp, node.hdb)
 	api := api.AuthMiddleware(renter, password)
 	web := createUIHandler()
 	return http.Serve(l, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/hostdbutil/db.go
+++ b/internal/hostdbutil/db.go
@@ -65,6 +65,13 @@ func (db *EphemeralDB) ProcessChainRevertUpdate(cru *chain.RevertUpdate) error {
 	return nil
 }
 
+// Host returns information about a host.
+func (db *EphemeralDB) Host(hostKey types.PublicKey) hostdb.Host {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	return db.hosts[hostKey]
+}
+
 // RecordInteraction records an interaction with a host. If the host is not in
 // the store, a new entry is created for it.
 func (db *EphemeralDB) RecordInteraction(hostKey types.PublicKey, hi hostdb.Interaction) error {

--- a/internal/hostdbutil/db.go
+++ b/internal/hostdbutil/db.go
@@ -66,10 +66,10 @@ func (db *EphemeralDB) ProcessChainRevertUpdate(cru *chain.RevertUpdate) error {
 }
 
 // Host returns information about a host.
-func (db *EphemeralDB) Host(hostKey types.PublicKey) hostdb.Host {
+func (db *EphemeralDB) Host(hostKey types.PublicKey) (hostdb.Host, error) {
 	db.mu.Lock()
 	defer db.mu.Unlock()
-	return db.hosts[hostKey]
+	return db.hosts[hostKey], nil
 }
 
 // RecordInteraction records an interaction with a host. If the host is not in

--- a/internal/hostdbutil/db_test.go
+++ b/internal/hostdbutil/db_test.go
@@ -1,0 +1,120 @@
+package hostdbutil
+
+import (
+	"encoding/json"
+	"math"
+	"os"
+	"reflect"
+	"testing"
+	"time"
+
+	"go.sia.tech/core/chain"
+	"go.sia.tech/core/net/rhp"
+	"go.sia.tech/core/types"
+	"go.sia.tech/siad/v2/hostdb"
+	"go.sia.tech/siad/v2/internal/chainutil"
+)
+
+type hostDB interface {
+	chain.Subscriber
+	RecordInteraction(hostKey types.PublicKey, hi hostdb.Interaction) error
+	SetScore(hostKey types.PublicKey, score float64) error
+	SelectHosts(n int, filter func(hostdb.Host) bool) []hostdb.Host
+	Host(hostKey types.PublicKey) hostdb.Host
+}
+
+func TestDBs(t *testing.T) {
+	sim := chainutil.NewChainSim()
+
+	ephemeralDB := NewEphemeralDB()
+	dir, err := os.MkdirTemp(os.TempDir(), t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+	jsonDB, _, err := NewJSONDB(dir, types.ChainIndex{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, db := range []hostDB{ephemeralDB, jsonDB} {
+		cm := chain.NewManager(chainutil.NewEphemeralStore(sim.Genesis), sim.State)
+		cm.AddSubscriber(db, cm.Tip())
+
+		const netAddress = "127.0.0.1:9999"
+		txn := types.Transaction{
+			Attestations: []types.Attestation{{
+				Key:   "Host Announcement",
+				Value: []byte(netAddress),
+			}},
+		}
+
+		b := sim.MineBlockWithTxns(txn)
+		if err := cm.AddTipBlock(b); err != nil {
+			t.Fatal(err)
+		}
+
+		hosts := db.SelectHosts(math.MaxInt64, func(hostdb.Host) bool { return true })
+
+		if len(hosts) != 1 {
+			t.Fatalf("expected only 1 host, got %d", len(hosts))
+		}
+
+		pk := hosts[0].PublicKey
+
+		expected := hostdb.Host{
+			PublicKey: pk,
+			Score:     0,
+			Announcements: []hostdb.Announcement{{
+				Index:      b.Index(),
+				Timestamp:  b.Header.Timestamp,
+				NetAddress: netAddress,
+			}},
+			Interactions: nil,
+		}
+		if !reflect.DeepEqual(expected, db.Host(pk)) {
+			t.Fatalf("expected host %+v, got %+v", expected, db.Host(pk))
+		}
+
+		if err := db.SetScore(pk, 100); err != nil {
+			t.Fatal(err)
+		}
+		expected.Score = 100
+		if !reflect.DeepEqual(expected, db.Host(pk)) {
+			t.Fatalf("expected host %+v, got %+v", expected, db.Host(pk))
+		}
+
+		settings := rhp.HostSettings{AcceptingContracts: true}
+		data, err := json.Marshal(settings)
+		if err != nil {
+			t.Fatal(err)
+		}
+		interaction := hostdb.Interaction{
+			Timestamp: time.Now(),
+			Type:      "scan",
+			Success:   true,
+			Result:    data,
+		}
+		if err := db.RecordInteraction(pk, interaction); err != nil {
+			t.Fatal(err)
+		}
+		expected.Interactions = append(expected.Interactions, interaction)
+
+		if !reflect.DeepEqual(expected, db.Host(pk)) {
+			t.Fatalf("expected host %+v, got %+v", expected, db.Host(pk))
+		}
+
+		host := db.Host(pk)
+		if host.NetAddress() != netAddress {
+			t.Fatalf("expected net address %s, got %s", netAddress, host.NetAddress())
+		}
+
+		hostSettings, ok := host.LastKnownSettings()
+		if !ok {
+			t.Fatal("host has no settings")
+		}
+		if hostSettings.AcceptingContracts != true {
+			t.Fatalf("expected host to be accepting contracts")
+		}
+	}
+}


### PR DESCRIPTION
Adds HostDB API endpoints in renterd.

```
GET  /api/hostdb                  (list all host pubkeys; should use some form of pagination)
GET  /api/hostdb/:pk              (lookup a host in the DB)
PUT  /api/hostdb/:pk/score        (set the host's score)
POST /api/hostdb/:pk/interaction  (record an interaction)
```