### PR TITLE
Remove "/api" prefix from client functions

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -22,7 +22,7 @@ func (c *Client) req(method string, route string, data, resp interface{}) error 
 		js, _ := json.Marshal(data)
 		body = bytes.NewReader(js)
 	}
-	req, err := http.NewRequest(method, fmt.Sprintf("%v%v", c.BaseURL, route), body)
+	req, err := http.NewRequest(method, fmt.Sprintf("%v/api%v", c.BaseURL, route), body)
 	if err != nil {
 		panic(err)
 	}

--- a/api/api.go
+++ b/api/api.go
@@ -22,7 +22,7 @@ func (c *Client) req(method string, route string, data, resp interface{}) error 
 		js, _ := json.Marshal(data)
 		body = bytes.NewReader(js)
 	}
-	req, err := http.NewRequest(method, fmt.Sprintf("%v/api%v", c.BaseURL, route), body)
+	req, err := http.NewRequest(method, fmt.Sprintf("%v%v", c.BaseURL, route), body)
 	if err != nil {
 		panic(err)
 	}

--- a/api/explored/client.go
+++ b/api/explored/client.go
@@ -12,31 +12,31 @@ type Client struct {
 
 // TxpoolBroadcast broadcasts a transaction to the network.
 func (c *Client) TxpoolBroadcast(txn types.Transaction, dependsOn []types.Transaction) (err error) {
-	err = c.c.Post("/api/txpool/broadcast", TxpoolBroadcastRequest{dependsOn, txn}, nil)
+	err = c.c.Post("/txpool/broadcast", TxpoolBroadcastRequest{dependsOn, txn}, nil)
 	return
 }
 
 // TxpoolTransactions returns all transactions in the transaction pool.
 func (c *Client) TxpoolTransactions() (resp []types.Transaction, err error) {
-	err = c.c.Get("/api/txpool/transactions", &resp)
+	err = c.c.Get("/txpool/transactions", &resp)
 	return
 }
 
 // SyncerPeers returns the current peers of the syncer.
 func (c *Client) SyncerPeers() (resp []SyncerPeerResponse, err error) {
-	err = c.c.Get("/api/syncer/peers", &resp)
+	err = c.c.Get("/syncer/peers", &resp)
 	return
 }
 
 // SyncerConnect adds the address as a peer of the syncer.
 func (c *Client) SyncerConnect(addr string) (err error) {
-	err = c.c.Post("/api/syncer/connect", addr, nil)
+	err = c.c.Post("/syncer/connect", addr, nil)
 	return
 }
 
 // ConsensusTip reports information about the current consensus state.
 func (c *Client) ConsensusTip() (resp ConsensusTipResponse, err error) {
-	err = c.c.Get("/api/consensus/tip", &resp)
+	err = c.c.Get("/consensus/tip", &resp)
 	return
 }
 

--- a/api/renterd/client.go
+++ b/api/renterd/client.go
@@ -25,56 +25,56 @@ type Client struct {
 
 // WalletBalance returns the current wallet balance.
 func (c *Client) WalletBalance() (resp WalletBalanceResponse, err error) {
-	err = c.c.Get("/api/wallet/balance", &resp)
+	err = c.c.Get("/wallet/balance", &resp)
 	return
 }
 
 // WalletAddress returns an address controlled by the wallet.
 func (c *Client) WalletAddress() (resp types.Address, err error) {
-	err = c.c.Get("/api/wallet/address", &resp)
+	err = c.c.Get("/wallet/address", &resp)
 	return
 }
 
 // WalletTransactions returns all transactions relevant to the wallet.
 func (c *Client) WalletTransactions(since time.Time, max int) (resp []wallet.Transaction, err error) {
-	err = c.c.Get(fmt.Sprintf("/api/wallet/transactions?since=%s&max=%d", since.Format(time.RFC3339), max), &resp)
+	err = c.c.Get(fmt.Sprintf("/wallet/transactions?since=%s&max=%d", since.Format(time.RFC3339), max), &resp)
 	return
 }
 
 // SyncerPeers returns the current peers of the syncer.
 func (c *Client) SyncerPeers() (resp []SyncerPeerResponse, err error) {
-	err = c.c.Get("/api/syncer/peers", &resp)
+	err = c.c.Get("/syncer/peers", &resp)
 	return
 }
 
 // SyncerConnect adds the address as a peer of the syncer.
 func (c *Client) SyncerConnect(addr string) (err error) {
-	err = c.c.Post("/api/syncer/connect", addr, nil)
+	err = c.c.Post("/syncer/connect", addr, nil)
 	return
 }
 
 // RHPScan scans a host, returning its current settings.
 func (c *Client) RHPScan(netAddress string, hostKey types.PublicKey) (resp rhp.HostSettings, err error) {
-	err = c.c.Post("/api/rhp/scan", RHPScanRequest{netAddress, hostKey}, &resp)
+	err = c.c.Post("/rhp/scan", RHPScanRequest{netAddress, hostKey}, &resp)
 	return
 }
 
 // RHPForm forms a contract with a host.
 func (c *Client) RHPForm(req RHPFormRequest) (resp RHPFormResponse, err error) {
-	err = c.c.Post("/api/rhp/form", req, &resp)
+	err = c.c.Post("/rhp/form", req, &resp)
 	return
 }
 
 // RHPRenew renews an existing contract with a host.
 func (c *Client) RHPRenew(req RHPRenewRequest) (resp RHPRenewResponse, err error) {
-	err = c.c.Post("/api/rhp/renew", req, &resp)
+	err = c.c.Post("/rhp/renew", req, &resp)
 	return
 }
 
 // RHPRead invokes the Read RPC on a host, writing the response to w.
 func (c *Client) RHPRead(w io.Writer, rrr RHPReadRequest) (err error) {
 	js, _ := json.Marshal(rrr)
-	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%v%v", c.c.BaseURL, "/api/rhp/read"), bytes.NewReader(js))
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%v%v", c.c.BaseURL, "/rhp/read"), bytes.NewReader(js))
 	if err != nil {
 		panic(err)
 	}
@@ -104,7 +104,7 @@ func (c *Client) RHPAppend(rar RHPAppendRequest, sector *[rhp.SectorSize]byte) (
 	f.Write(sector[:])
 	w.Close()
 
-	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%v%v", c.c.BaseURL, "/api/rhp/append"), &buf)
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%v%v", c.c.BaseURL, "/rhp/append"), &buf)
 	if err != nil {
 		panic(err)
 	}
@@ -125,25 +125,25 @@ func (c *Client) RHPAppend(rar RHPAppendRequest, sector *[rhp.SectorSize]byte) (
 
 // HostDBHosts gets a list of hosts in the host DB.
 func (c *Client) HostDBHosts() (resp []hostdb.Host, err error) {
-	err = c.c.Get("/api/hostdb", &resp)
+	err = c.c.Get("/hostdb", &resp)
 	return
 }
 
 // HostDBHost gets information about a given host.
 func (c *Client) HostDBHost(hostKey types.PublicKey) (resp []hostdb.Host, err error) {
-	err = c.c.Get(fmt.Sprintf("/api/hostdb/%s", hostKey), &resp)
+	err = c.c.Get(fmt.Sprintf("/hostdb/%s", hostKey), &resp)
 	return
 }
 
 // HostDBScore assigns a score to a given host.
 func (c *Client) HostDBScore(hostKey types.PublicKey, score float64) (err error) {
-	err = c.c.Put(fmt.Sprintf("/api/hostdb/%s/score", hostKey), HostDBScoreRequest{score})
+	err = c.c.Put(fmt.Sprintf("/hostdb/%s/score", hostKey), HostDBScoreRequest{score})
 	return
 }
 
 // HostDBInteractions records interactions with a given host.
 func (c *Client) HostDBInteractions(hostKey types.PublicKey, interactions []hostdb.Interaction) (err error) {
-	err = c.c.Put(fmt.Sprintf("/api/hostdb/%s/interactions", hostKey), interactions)
+	err = c.c.Put(fmt.Sprintf("/hostdb/%s/interactions", hostKey), interactions)
 	return
 }
 

--- a/api/siad/client.go
+++ b/api/siad/client.go
@@ -17,14 +17,14 @@ type Client struct {
 
 // ConsensusTip returns the current tip index.
 func (c *Client) ConsensusTip() (resp types.ChainIndex, err error) {
-	err = c.c.Get("/api/consensus/tip", &resp)
+	err = c.c.Get("/consensus/tip", &resp)
 	return
 }
 
 // ConsensusState returns the consensus state at the provided index.
 func (c *Client) ConsensusState(index types.ChainIndex) (resp consensus.State, err error) {
 	i, _ := index.MarshalText() // index.String is lossy
-	err = c.c.Get("/api/consensus/state/"+string(i), &resp)
+	err = c.c.Get("/consensus/state/"+string(i), &resp)
 	return
 }
 
@@ -39,72 +39,72 @@ func (c *Client) ConsensusTipState() (resp consensus.State, err error) {
 
 // ConsensusBroadcast broadcasts the provided block, which must attach to the current tip.
 func (c *Client) ConsensusBroadcast(b types.Block) error {
-	return c.c.Post("/api/consensus/broadcast", b, nil)
+	return c.c.Post("/consensus/broadcast", b, nil)
 }
 
 // WalletBalance returns the current wallet balance.
 func (c *Client) WalletBalance() (resp WalletBalanceResponse, err error) {
-	err = c.c.Get("/api/wallet/balance", &resp)
+	err = c.c.Get("/wallet/balance", &resp)
 	return
 }
 
 // WalletSeedIndex returns the current wallet seed index.
 func (c *Client) WalletSeedIndex() (index uint64, err error) {
-	err = c.c.Get("/api/wallet/seedindex", &index)
+	err = c.c.Get("/wallet/seedindex", &index)
 	return
 }
 
 // WalletAddAddress adds an address to the wallet.
 func (c *Client) WalletAddAddress(addr types.Address, info wallet.AddressInfo) (err error) {
-	err = c.c.Post("/api/wallet/address/"+addr.String(), info, nil)
+	err = c.c.Post("/wallet/address/"+addr.String(), info, nil)
 	return
 }
 
 // WalletAddressInfo returns information about an address controlled by the wallet.
 func (c *Client) WalletAddressInfo(addr types.Address) (resp wallet.AddressInfo, err error) {
-	err = c.c.Get("/api/wallet/address/"+addr.String(), &resp)
+	err = c.c.Get("/wallet/address/"+addr.String(), &resp)
 	return
 }
 
 // WalletAddresses returns all addresses controlled by the wallet.
 func (c *Client) WalletAddresses(start, end int) (resp WalletAddressesResponse, err error) {
-	err = c.c.Get(fmt.Sprintf("/api/wallet/addresses?start=%d&end=%d", start, end), &resp)
+	err = c.c.Get(fmt.Sprintf("/wallet/addresses?start=%d&end=%d", start, end), &resp)
 	return
 }
 
 // WalletTransactions returns all transactions relevant to the wallet.
 func (c *Client) WalletTransactions(since time.Time, max int) (resp []wallet.Transaction, err error) {
-	err = c.c.Get(fmt.Sprintf("/api/wallet/transactions?since=%s&max=%d", since.Format(time.RFC3339), max), &resp)
+	err = c.c.Get(fmt.Sprintf("/wallet/transactions?since=%s&max=%d", since.Format(time.RFC3339), max), &resp)
 	return
 }
 
 // WalletUTXOs returns all unspent outputs controlled by the wallet.
 func (c *Client) WalletUTXOs() (resp WalletUTXOsResponse, err error) {
-	err = c.c.Get("/api/wallet/utxos", &resp)
+	err = c.c.Get("/wallet/utxos", &resp)
 	return
 }
 
 // TxpoolBroadcast broadcasts a transaction to the network.
 func (c *Client) TxpoolBroadcast(txn types.Transaction, dependsOn []types.Transaction) (err error) {
-	err = c.c.Post("/api/txpool/broadcast", TxpoolBroadcastRequest{dependsOn, txn}, nil)
+	err = c.c.Post("/txpool/broadcast", TxpoolBroadcastRequest{dependsOn, txn}, nil)
 	return
 }
 
 // TxpoolTransactions returns all transactions in the transaction pool.
 func (c *Client) TxpoolTransactions() (resp []types.Transaction, err error) {
-	err = c.c.Get("/api/txpool/transactions", &resp)
+	err = c.c.Get("/txpool/transactions", &resp)
 	return
 }
 
 // SyncerPeers returns the current peers of the syncer.
 func (c *Client) SyncerPeers() (resp []SyncerPeerResponse, err error) {
-	err = c.c.Get("/api/syncer/peers", &resp)
+	err = c.c.Get("/syncer/peers", &resp)
 	return
 }
 
 // SyncerConnect adds the address as a peer of the syncer.
 func (c *Client) SyncerConnect(addr string) (err error) {
-	err = c.c.Post("/api/syncer/connect", addr, nil)
+	err = c.c.Post("/syncer/connect", addr, nil)
 	return
 }
 

--- a/cmd/siac/main.go
+++ b/cmd/siac/main.go
@@ -169,7 +169,7 @@ func getClient() *siad.Client {
 	if !strings.HasPrefix(siadAddr, "https://") && !strings.HasPrefix(siadAddr, "http://") {
 		siadAddr = "http://" + siadAddr
 	}
-	c := siad.NewClient(siadAddr, password)
+	c := siad.NewClient(siadAddr+"/api", password)
 	_, err := c.ConsensusTip()
 	check("Couldn't connect to siad:", err)
 	siadClient = c


### PR DESCRIPTION
Makes Client.req add the "/api" prefix after BaseURL.