### PR TITLE
Fix /renter/stream TTFB

### DIFF
--- a/node/api/routes.go
+++ b/node/api/routes.go
@@ -1,8 +1,7 @@
 package api
 
 import (
-	"encoding/json"
-	"fmt"
+	"context"
 	"net/http"
 	"strings"
 	"time"
@@ -148,15 +147,23 @@ func (api *API) buildHTTPRoutes() {
 	}
 
 	// Apply UserAgent middleware and return the Router
-	timeoutErr := Error{fmt.Sprintf("HTTP call exceeded the timeout of %v", httpServerTimeout)}
-	jsonErr, err := json.Marshal(timeoutErr)
-	if err != nil {
-		build.Critical("marshalling error on object that should be safe to marshal:", err)
-	}
 	api.routerMu.Lock()
-	api.router = http.TimeoutHandler(RequireUserAgent(router, requiredUserAgent), httpServerTimeout, string(jsonErr))
+	api.router = timeoutHandler(RequireUserAgent(router, requiredUserAgent), httpServerTimeout)
 	api.routerMu.Unlock()
 	return
+}
+
+// timeoutHandler is a middleware that enforces a specific timeout on the route
+// by closing the context after the httpServerTimeout.
+func timeoutHandler(h http.Handler, timeout time.Duration) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		// Create a new context with timeout.
+		ctx, cancel := context.WithTimeout(req.Context(), httpServerTimeout)
+		defer cancel()
+
+		// Add the new context to the request and call the handler.
+		h.ServeHTTP(w, req.WithContext(ctx))
+	})
 }
 
 // RequireUserAgent is middleware that requires all requests to set a

--- a/node/api/server_test.go
+++ b/node/api/server_test.go
@@ -1,14 +1,8 @@
 package api
 
 import (
-	"encoding/json"
-	"fmt"
-	"io/ioutil"
 	"net/http"
 	"testing"
-
-	"go.sia.tech/siad/modules"
-	"go.sia.tech/siad/siatest/dependencies"
 )
 
 // TestExplorerPreset checks that the default configuration for the explorer is
@@ -64,58 +58,6 @@ func TestReloading(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-	}
-}
-
-// TestServerTimeout verifies the server returns a Gateway Timeout if an HTTP
-// call exceeds the predefined timeout period.
-func TestServerTimeout(t *testing.T) {
-	if testing.Short() {
-		t.SkipNow()
-	}
-	t.Parallel()
-
-	apiDeps := &dependencies.DependencyTimeoutOnHostGET{}
-	st, err := createServerTesterWithDeps(t.Name(), modules.ProdDependencies, modules.ProdDependencies, modules.ProdDependencies, modules.ProdDependencies, modules.ProdDependencies, modules.ProdDependencies, modules.ProdDependencies, modules.ProdDependencies, modules.ProdDependencies, apiDeps)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	defer func() {
-		err = st.server.Close()
-		if err != nil {
-			t.Fatal(err)
-		}
-	}()
-
-	// Test that the call times out
-	testGETURL := "http://" + st.server.listener.Addr().String() + "/host"
-	resp, err := HttpGET(testGETURL)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Verify status code
-	if resp.StatusCode != http.StatusServiceUnavailable {
-		t.Fatalf("Expected HTTP Status Code to be %v, instead it was %v", http.StatusServiceUnavailable, resp.StatusCode)
-	}
-
-	// Verify response body
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Parse error.
-	var msg Error
-	err = json.Unmarshal(body, &msg)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Verify error msg
-	if msg.Message != fmt.Sprintf("HTTP call exceeded the timeout of %v", httpServerTimeout) {
-		t.Fatal("Expected response body to contain the custom error message")
 	}
 }
 


### PR DESCRIPTION
`http.timeoutHandler` buffers the entire response in memory until the HTTP handler returns; this causes files downloaded by `/renter/stream` to be buffered in memory until completely downloaded instead of streamed. 

Pulls in the change from `skyd` https://gitlab.com/SkynetLabs/skyd/-/commit/913ca81136671fd6f81dfa2b8a20e00a42afd9bc