### PR TITLE
fix: fund txn adds change address to wallet

### DIFF
--- a/cmd/siac/main.go
+++ b/cmd/siac/main.go
@@ -576,6 +576,10 @@ func fundTxn(txn *types.Transaction, seed wallet.Seed) error {
 			Description: "change addr for " + txn.ID().String(),
 		}
 		addr := types.StandardAddress(seed.PublicKey(info.Index))
+		err = getClient().WalletAddAddress(addr, info)
+		if err != nil {
+			return err
+		}
 		txn.SiacoinOutputs = append(txn.SiacoinOutputs, types.SiacoinOutput{
 			Value:   outputSum.Sub(amount),
 			Address: addr,


### PR DESCRIPTION
While using `siac`, noticed the wallet was returning incorrect `Inflow` and `Outflow` values on txns, looks to be because the change address is not being added to the wallet's store.