### PR TITLE
Docker timezone support fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY . .
 
 # need to run git status first to fix GIT_DIRTY detection in makefile
 RUN apk update \
-	&& apk add --no-cache build-base git make ca-certificates \
+	&& apk add --no-cache build-base git make ca-certificates tzdata \
 	&& update-ca-certificates \
 	&& git status > /dev/null \
 	&& make static
@@ -28,6 +28,9 @@ EXPOSE 9983/tcp
 ENV SIA_WALLET_PASSWORD=
 # SIA_API_PASSWORD sets the password used for API authentication
 ENV SIA_API_PASSWORD=
+
+# TZ used to set local timezone
+ENV TZ=
 
 VOLUME [ "/sia-data" ]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN apk update \
 FROM alpine:latest
 
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=build /usr/share/zoneinfo /usr/share/zoneinfo
 COPY --from=build /app/release /
 
 # gateway port


### PR DESCRIPTION
To support setting the timezone for siad docker image the docker build needs tzinfo package, a TZ environment variable set, and the zoneinfo data from the build copied. 

This increases the image size from 33.3MB to 34.4MB

Tested by building and running an image with submitted Dockerfile using TZ env variable and checking `date` output. 
FYI, also attempted to set volume mounts on existing published image for /etc/timezone /etc/localtime and /usr/share/zoneinfo and could not get the image to detect the TZ env variable. 
