### PR TITLE
Close mux log when node is closed

### DIFF
--- a/build/debug_on.go
+++ b/build/debug_on.go
@@ -1,3 +1,4 @@
+//go:build debug
 // +build debug
 
 package build

--- a/build/release_dev.go
+++ b/build/release_dev.go
@@ -1,3 +1,4 @@
+//go:build dev
 // +build dev
 
 package build

--- a/build/release_testing.go
+++ b/build/release_testing.go
@@ -1,3 +1,4 @@
+//go:build testing
 // +build testing
 
 package build

--- a/build/var.go
+++ b/build/var.go
@@ -19,8 +19,8 @@ type Var struct {
 // important to point out that type assertions are stricter than conversions.
 // Specifically, you cannot write:
 //
-//   type myint int
-//   Select(Var{0, 0, 0}).(myint)
+//	type myint int
+//	Select(Var{0, 0, 0}).(myint)
 //
 // Because 0 will be interpreted as an int, which is not assignable to myint.
 // Instead, you must explicitly cast each field in the Var, or cast the return

--- a/build/version.go
+++ b/build/version.go
@@ -63,9 +63,9 @@ func splitVersion(v string) (version []int, rc int) {
 // VersionCmp returns an int indicating the difference between a and b. It
 // follows the convention of bytes.Compare and big.Cmp:
 //
-//   -1 if a <  b
-//    0 if a == b
-//   +1 if a >  b
+//	-1 if a <  b
+//	 0 if a == b
+//	+1 if a >  b
 //
 // One important quirk is that "1.1.0" is considered newer than "1.1", despite
 // being numerically equal.

--- a/cmd/siac/gatewaycmd.go
+++ b/cmd/siac/gatewaycmd.go
@@ -144,8 +144,8 @@ func gatewayaddresscmd() {
 	fmt.Println("Address:", info.NetAddress)
 }
 
-//gatewaybandwidthcmd is the handler for the command `siac gateway bandwidth`.
-//returns the total upload and download bandwidth usage for the gateway
+// gatewaybandwidthcmd is the handler for the command `siac gateway bandwidth`.
+// returns the total upload and download bandwidth usage for the gateway
 func gatewaybandwidthcmd() {
 	bandwidth, err := httpClient.GatewayBandwidthGet()
 	if err != nil {

--- a/cmd/siac/rentercmd.go
+++ b/cmd/siac/rentercmd.go
@@ -1930,9 +1930,9 @@ func renterfuseunmountcmd(path string) {
 	fmt.Printf("Unmounted %s successfully\n", path)
 }
 
-//rentersetlocalpathcmd is the handler for the command `siac renter setlocalpath [siapath] [newlocalpath]`
-//Changes the trackingpath of the file
-//through API Endpoint
+// rentersetlocalpathcmd is the handler for the command `siac renter setlocalpath [siapath] [newlocalpath]`
+// Changes the trackingpath of the file
+// through API Endpoint
 func rentersetlocalpathcmd(siapath, newlocalpath string) {
 	//Parse Siapath
 	siaPath, err := modules.NewSiaPath(siapath)

--- a/internal/smux/session_test.go
+++ b/internal/smux/session_test.go
@@ -16,6 +16,7 @@ import (
 
 func init() {
 	go func() {
+		// nolint:gosec
 		log.Println(http.ListenAndServe("localhost:6060", nil))
 	}()
 	log.SetFlags(log.LstdFlags | log.Lshortfile)

--- a/modules/consensus/processedblock.go
+++ b/modules/consensus/processedblock.go
@@ -43,7 +43,8 @@ type processedBlock struct {
 // heavierThan returns true if the blockNode is sufficiently heavier than
 // 'cmp'. 'cmp' is expected to be the current block node. "Sufficient" means
 // that the weight of 'bn' exceeds the weight of 'cmp' by:
-//		(the target of 'cmp' * 'Surpass Threshold')
+//
+//	(the target of 'cmp' * 'Surpass Threshold')
 func (pb *processedBlock) heavierThan(cmp *processedBlock) bool {
 	requirement := cmp.Depth.AddDifficulties(cmp.ChildTarget.MulDifficulty(SurpassThreshold))
 	return requirement.Cmp(pb.Depth) > 0 // Inversed, because the smaller target is actually heavier.

--- a/modules/consensus/synchronize_ibd_test.go
+++ b/modules/consensus/synchronize_ibd_test.go
@@ -301,8 +301,8 @@ func TestInitialBlockchainDownloadDisconnects(t *testing.T) {
 // TestInitialBlockchainDownloadDoneRules tests that
 // managedInitialBlockchainDownload only terminates under the appropriate
 // conditions. Appropriate conditions are:
-//  - at least minNumOutbound synced outbound peers
-//  - or at least 1 synced outbound peer and minIBDWaitTime has passed since beginning IBD.
+//   - at least minNumOutbound synced outbound peers
+//   - or at least 1 synced outbound peer and minIBDWaitTime has passed since beginning IBD.
 func TestInitialBlockchainDownloadDoneRules(t *testing.T) {
 	if testing.Short() || !build.VLONG {
 		t.SkipNow()

--- a/modules/consensus/validtransaction.go
+++ b/modules/consensus/validtransaction.go
@@ -102,7 +102,7 @@ func storageProofSegment(tx *bolt.Tx, fcid types.FileContractID) (uint64, error)
 // validStorageProofsPre100e3 runs the code that was running before height
 // 100e3, which contains a hardforking bug, fixed at block 100e3.
 //
-// HARDFORK 100,000
+// # HARDFORK 100,000
 //
 // Originally, it was impossible to provide a storage proof for data of length
 // zero. A hardfork was added triggering at block 100,000 to enable an

--- a/modules/host/host_test.go
+++ b/modules/host/host_test.go
@@ -136,7 +136,7 @@ func blankMockHostTester(d modules.Dependencies, name string) (*hostTester, erro
 
 	// Create the siamux.
 	siaMuxDir := filepath.Join(testdir, modules.SiaMuxDir)
-	mux, err := modules.NewSiaMux(siaMuxDir, testdir, "localhost:0", "localhost:0")
+	mux, _, err := modules.NewSiaMux(siaMuxDir, testdir, "localhost:0", "localhost:0")
 	if err != nil {
 		return nil, err
 	}

--- a/modules/host/persist_compat_1.0.0_test.go
+++ b/modules/host/persist_compat_1.0.0_test.go
@@ -43,7 +43,7 @@ func TestHostPersistCompat100(t *testing.T) {
 	// Create a new siamux to ensure it has the chance to load the appropriate
 	// set of keys
 	siaMuxDir := filepath.Join(ht.persistDir, modules.SiaMuxDir)
-	mux, err := modules.NewSiaMux(siaMuxDir, ht.persistDir, "localhost:0", "localhost:0")
+	mux, _, err := modules.NewSiaMux(siaMuxDir, ht.persistDir, "localhost:0", "localhost:0")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/host/persist_compat_1.2.0.go
+++ b/modules/host/persist_compat_1.2.0.go
@@ -102,7 +102,7 @@ type (
 // compatibility with previous versions, enabling users to upgrade without
 // unexpected loss of data.
 //
-// COMPAT v1.0.0
+// # COMPAT v1.0.0
 //
 // A spelling error in pre-1.0 versions means that, if this is the first time
 // running after an upgrade, the misspelled field needs to be transferred over.

--- a/modules/host/persist_compat_1.2.0_test.go
+++ b/modules/host/persist_compat_1.2.0_test.go
@@ -26,7 +26,7 @@ const (
 // then load the host on top of the given directory.
 func loadExistingHostWithNewDeps(modulesDir, siaMuxDir, hostDir string) (closeFn, modules.Host, error) {
 	// Create the siamux
-	mux, err := modules.NewSiaMux(siaMuxDir, modulesDir, "localhost:0", "localhost:0")
+	mux, _, err := modules.NewSiaMux(siaMuxDir, modulesDir, "localhost:0", "localhost:0")
 	if err != nil {
 		return nil, nil, err
 	}

--- a/modules/host/registry/registry_test.go
+++ b/modules/host/registry/registry_test.go
@@ -911,7 +911,6 @@ func TestRegistryRace(t *testing.T) {
 // CPU | DiskType | #CPUs | #Updates/s | Commit
 //
 // i9  | SSD      | 16    | 196        | 1a862b7bace95e968f04f0a2151e5a572c948f22
-//
 func BenchmarkRegistryUpdate(b *testing.B) {
 	b.StopTimer()
 	dir := testDir(b.Name())

--- a/modules/packing.go
+++ b/modules/packing.go
@@ -66,32 +66,32 @@ type (
 // 2. Going from larger to smaller files, try to fit each file into an available
 // bucket in a sector.
 //
-//   a. The first of the largest available buckets should be chosen.
+//	a. The first of the largest available buckets should be chosen.
 //
-//   b. The first byte of the file must be aligned to a certain multiple of KiB,
-//   based on its size.
+//	b. The first byte of the file must be aligned to a certain multiple of KiB,
+//	based on its size.
 //
-//     i. For a file size up to 32*2^n KiB, the file must align to 4*2^n KiB,
-//     for 0 <= n <= 7.
+//	  i. For a file size up to 32*2^n KiB, the file must align to 4*2^n KiB,
+//	  for 0 <= n <= 7.
 //
-//     ii. Alignment is based on the start of the sector, not the bucket.
+//	  ii. Alignment is based on the start of the sector, not the bucket.
 //
-//     iii. Alignment may cause a file not to fit into an otherwise large-enough
-//     bucket.
+//	  iii. Alignment may cause a file not to fit into an otherwise large-enough
+//	  bucket.
 //
-//   c. If there are no suitable buckets, create a new sector and a new bucket
-//   in that sector that fills the whole sector.
+//	c. If there are no suitable buckets, create a new sector and a new bucket
+//	in that sector that fills the whole sector.
 //
 // 3. Pack the file into the bucket at the correct alignment.
 //
-//   a. Delete the bucket and make up to 2 new buckets. The new buckets, if any,
-//   should stay ordered with regards to their positions in the sectors:
+//	a. Delete the bucket and make up to 2 new buckets. The new buckets, if any,
+//	should stay ordered with regards to their positions in the sectors:
 //
-//     i. If the file could not align to the start of the bucket, make a new
-//     bucket from the start of the old bucket to the start of the file.
+//	  i. If the file could not align to the start of the bucket, make a new
+//	  bucket from the start of the old bucket to the start of the file.
 //
-//     ii. If the file does not go to the end of the bucket, make a new bucket
-//     that goes from the end of the file to the end of the old bucket.
+//	  ii. If the file does not go to the end of the bucket, make a new bucket
+//	  that goes from the end of the file to the end of the old bucket.
 //
 // 4. Return the slice of file placements in the order that they were packed
 // chronologically. Note that they may be out of order positionally, as smaller

--- a/modules/renter/bubble_bench_test.go
+++ b/modules/renter/bubble_bench_test.go
@@ -35,7 +35,6 @@ func newBenchmarkRenterWithDependency(name string, deps modules.Dependencies) (*
 // linux, amd64, Intel(R) Core(TM) i7-8550U CPU @ 1.80GHz: 34 |  34416443 ns/op                                 11/10/2020
 // linux, amd64, Intel(R) Core(TM) i7-8550U CPU @ 1.80GHz: 15 |  75880486 ns/op                                 02/26/2021
 // linux, amd64, Intel(R) Core(TM) i7-8550U CPU @ 1.80GHz: 19 |  59483353 ns/op                                 03/05/2021
-//
 func BenchmarkBubbleMetadata(b *testing.B) {
 	r, err := newBenchmarkRenterWithDependency(b.Name(), &dependencies.DependencyDisableRepairAndHealthLoops{})
 	if err != nil {

--- a/modules/renter/contractor/contractor_test.go
+++ b/modules/renter/contractor/contractor_test.go
@@ -57,7 +57,7 @@ func newModules(testdir string) (modules.ConsensusSet, modules.Wallet, modules.T
 		return nil, nil, nil, nil, nil, nil, err
 	}
 	siaMuxDir := filepath.Join(testdir, modules.SiaMuxDir)
-	mux, err := modules.NewSiaMux(siaMuxDir, testdir, "localhost:0", "localhost:0")
+	mux, _, err := modules.NewSiaMux(siaMuxDir, testdir, "localhost:0", "localhost:0")
 	if err != nil {
 		return nil, nil, nil, nil, nil, nil, err
 	}
@@ -157,7 +157,7 @@ func TestIntegrationSetAllowance(t *testing.T) {
 	// create a siamux
 	testdir := build.TempDir("contractor", t.Name())
 	siaMuxDir := filepath.Join(testdir, modules.SiaMuxDir)
-	mux, err := modules.NewSiaMux(siaMuxDir, testdir, "localhost:0", "localhost:0")
+	mux, _, err := modules.NewSiaMux(siaMuxDir, testdir, "localhost:0", "localhost:0")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -511,7 +511,7 @@ func TestPayment(t *testing.T) {
 	// create a siamux
 	testdir := build.TempDir("contractor", t.Name())
 	siaMuxDir := filepath.Join(testdir, modules.SiaMuxDir)
-	mux, err := modules.NewSiaMux(siaMuxDir, testdir, "localhost:0", "localhost:0")
+	mux, _, err := modules.NewSiaMux(siaMuxDir, testdir, "localhost:0", "localhost:0")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -828,7 +828,7 @@ func TestPaymentMissingStorageObligation(t *testing.T) {
 	// create a siamux
 	testdir := build.TempDir("contractor", t.Name())
 	siaMuxDir := filepath.Join(testdir, modules.SiaMuxDir)
-	mux, err := modules.NewSiaMux(siaMuxDir, testdir, "localhost:0", "localhost:0")
+	mux, _, err := modules.NewSiaMux(siaMuxDir, testdir, "localhost:0", "localhost:0")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/renter/contractor/host_integration_test.go
+++ b/modules/renter/contractor/host_integration_test.go
@@ -122,7 +122,7 @@ func newTestingContractor(testdir string, g modules.Gateway, cs modules.Consensu
 		return nil, nil, err
 	}
 	siaMuxDir := filepath.Join(testdir, modules.SiaMuxDir)
-	mux, err := modules.NewSiaMux(siaMuxDir, testdir, "localhost:0", "localhost:0")
+	mux, _, err := modules.NewSiaMux(siaMuxDir, testdir, "localhost:0", "localhost:0")
 	if err != nil {
 		return nil, nil, err
 	}
@@ -154,7 +154,7 @@ func newTestingTrioWithContractorDeps(name string, deps modules.Dependencies) (m
 
 	// create mux
 	siaMuxDir := filepath.Join(testdir, modules.SiaMuxDir)
-	mux, err := modules.NewSiaMux(siaMuxDir, testdir, "localhost:0", "localhost:0")
+	mux, _, err := modules.NewSiaMux(siaMuxDir, testdir, "localhost:0", "localhost:0")
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}

--- a/modules/renter/contractor/negotiate_test.go
+++ b/modules/renter/contractor/negotiate_test.go
@@ -74,7 +74,7 @@ func newContractorTester(name string) (*contractorTester, closeFn, error) {
 		return nil, nil, err
 	}
 	siaMuxDir := filepath.Join(testdir, modules.SiaMuxDir)
-	mux, err := modules.NewSiaMux(siaMuxDir, testdir, "localhost:0", "localhost:0")
+	mux, _, err := modules.NewSiaMux(siaMuxDir, testdir, "localhost:0", "localhost:0")
 	if err != nil {
 		return nil, nil, err
 	}

--- a/modules/renter/contractor/watchdog_test.go
+++ b/modules/renter/contractor/watchdog_test.go
@@ -72,15 +72,15 @@ func createFakeRevisionTxn(fcID types.FileContractID, revNum uint64, windowStart
 // |      |        |    ...   |       |        |
 // |      |        |          |       |        |
 // ----------------------+----------------------
-//                       |
-//                       +
-//                       |
-//                       .
-//                       .
-//                       .
-//                       |
-//                       +
 //
+//	|
+//	+
+//	|
+//	.
+//	.
+//	.
+//	|
+//	+
 func createTestTransactionTree(numRoots int, chainLength int) (txnSet []types.Transaction, roots []types.Transaction, subRootTx types.Transaction, fcTxn types.Transaction, rootParentOutputs map[types.SiacoinOutputID]bool) {
 	roots = make([]types.Transaction, 0, numRoots)
 	rootParents := make(map[types.SiacoinOutputID]bool)

--- a/modules/renter/hostdb/hostdb_test.go
+++ b/modules/renter/hostdb/hostdb_test.go
@@ -97,7 +97,7 @@ func newHDBTesterDeps(name string, deps modules.Dependencies) (*hdbTester, error
 	if err != nil {
 		return nil, err
 	}
-	mux, err := modules.NewSiaMux(filepath.Join(testDir, modules.SiaMuxDir), testDir, "localhost:0", "localhost:0")
+	mux, _, err := modules.NewSiaMux(filepath.Join(testDir, modules.SiaMuxDir), testDir, "localhost:0", "localhost:0")
 	if err != nil {
 		return nil, err
 	}
@@ -168,7 +168,7 @@ func TestNew(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	mux, err := modules.NewSiaMux(filepath.Join(testDir, modules.SiaMuxDir), testDir, "localhost:0", "localhost:0")
+	mux, _, err := modules.NewSiaMux(filepath.Join(testDir, modules.SiaMuxDir), testDir, "localhost:0", "localhost:0")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/renter/no_fuse_support_fusemanager.go
+++ b/modules/renter/no_fuse_support_fusemanager.go
@@ -1,3 +1,4 @@
+//go:build !linux && !darwin
 // +build !linux,!darwin
 
 package renter

--- a/modules/renter/registrystats_test.go
+++ b/modules/renter/registrystats_test.go
@@ -171,8 +171,9 @@ func TestReadRegistryStatsDecay(t *testing.T) {
 // BenchmarkAddDatum benchmarks AddDatum.
 //
 // maxTime | interval |   ops |                    cpu
-//   5 min |      1ms |  3222 | i9-9880H CPU @ 2.30GHz
-//   5 min |     10ms | 32263 | i9-9880H CPU @ 2.30GHz
+//
+//	5 min |      1ms |  3222 | i9-9880H CPU @ 2.30GHz
+//	5 min |     10ms | 32263 | i9-9880H CPU @ 2.30GHz
 func BenchmarkAddDatum(b *testing.B) {
 	// Create stats with at most 5 minute measurements.
 	// Add n datapoints to 5000 buckets.

--- a/modules/renter/renter_test.go
+++ b/modules/renter/renter_test.go
@@ -57,7 +57,7 @@ func (rt *renterTester) Close() error {
 func (rt *renterTester) addCustomHost(testdir string, deps modules.Dependencies) (modules.Host, error) {
 	// create a siamux for this particular host
 	siaMuxDir := filepath.Join(testdir, modules.SiaMuxDir)
-	mux, err := modules.NewSiaMux(siaMuxDir, testdir, "localhost:0", "localhost:0")
+	mux, _, err := modules.NewSiaMux(siaMuxDir, testdir, "localhost:0", "localhost:0")
 	if err != nil {
 		return nil, err
 	}
@@ -202,7 +202,7 @@ func newRenterTester(name string) (*renterTester, error) {
 func newRenterTesterNoRenter(testdir string) (*renterTester, error) {
 	// Create the siamux
 	siaMuxDir := filepath.Join(testdir, modules.SiaMuxDir)
-	mux, err := modules.NewSiaMux(siaMuxDir, testdir, "localhost:0", "localhost:0")
+	mux, _, err := modules.NewSiaMux(siaMuxDir, testdir, "localhost:0", "localhost:0")
 	if err != nil {
 		return nil, err
 	}
@@ -263,7 +263,7 @@ func newRenterTesterWithDependency(name string, deps modules.Dependencies) (*ren
 
 	// Create the siamux
 	siaMuxDir := filepath.Join(testdir, modules.SiaMuxDir)
-	mux, err := modules.NewSiaMux(siaMuxDir, testdir, "localhost:0", "localhost:0")
+	mux, _, err := modules.NewSiaMux(siaMuxDir, testdir, "localhost:0", "localhost:0")
 	if err != nil {
 		return nil, err
 	}

--- a/modules/siamux_test.go
+++ b/modules/siamux_test.go
@@ -22,7 +22,7 @@ func TestSiaMuxCompat(t *testing.T) {
 
 	// create a new siamux, seeing as there won't be a host persistence file, it
 	// will act as if this is a fresh new node and create a new key pair
-	mux, err := NewSiaMux(siaMuxDir, siaDataDir, "localhost:0", "localhost:0")
+	mux, _, err := NewSiaMux(siaMuxDir, siaDataDir, "localhost:0", "localhost:0")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -31,7 +31,7 @@ func TestSiaMuxCompat(t *testing.T) {
 	mux.Close()
 
 	// re-open the mux and verify it uses the same keys
-	mux, err = NewSiaMux(siaMuxDir, siaDataDir, "localhost:0", "localhost:0")
+	mux, _, err = NewSiaMux(siaMuxDir, siaDataDir, "localhost:0", "localhost:0")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -77,7 +77,7 @@ func TestSiaMuxCompat(t *testing.T) {
 	}
 
 	// create a new siamux
-	mux, err = NewSiaMux(siaMuxDir, siaDataDir, "localhost:0", "localhost:0")
+	mux, _, err = NewSiaMux(siaMuxDir, siaDataDir, "localhost:0", "localhost:0")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/wallet/update.go
+++ b/modules/wallet/update.go
@@ -1,7 +1,6 @@
 package wallet
 
 import (
-	"fmt"
 	"math"
 
 	"gitlab.com/NebulousLabs/bolt"
@@ -113,12 +112,9 @@ func (w *Wallet) updateConfirmedSet(tx *bolt.Tx, cc modules.ConsensusChange) err
 
 		var err error
 		if diff.Direction == modules.DiffApply {
-			fmt.Println("incoming")
-			fmt.Println("huehue", diff.SiacoinOutput.Value)
 			w.log.Println("Wallet has gained a spendable siacoin output:", diff.ID, "::", diff.SiacoinOutput.Value.HumanString())
 			err = dbPutSiacoinOutput(tx, diff.ID, diff.SiacoinOutput)
 		} else {
-			fmt.Println("outgoing")
 			w.log.Println("Wallet has lost a spendable siacoin output:", diff.ID, "::", diff.SiacoinOutput.Value.HumanString())
 			err = dbDeleteSiacoinOutput(tx, diff.ID)
 		}

--- a/modules/wallet/update.go
+++ b/modules/wallet/update.go
@@ -1,6 +1,7 @@
 package wallet
 
 import (
+	"fmt"
 	"math"
 
 	"gitlab.com/NebulousLabs/bolt"
@@ -112,9 +113,12 @@ func (w *Wallet) updateConfirmedSet(tx *bolt.Tx, cc modules.ConsensusChange) err
 
 		var err error
 		if diff.Direction == modules.DiffApply {
+			fmt.Println("incoming")
+			fmt.Println("huehue", diff.SiacoinOutput.Value)
 			w.log.Println("Wallet has gained a spendable siacoin output:", diff.ID, "::", diff.SiacoinOutput.Value.HumanString())
 			err = dbPutSiacoinOutput(tx, diff.ID, diff.SiacoinOutput)
 		} else {
+			fmt.Println("outgoing")
 			w.log.Println("Wallet has lost a spendable siacoin output:", diff.ID, "::", diff.SiacoinOutput.Value.HumanString())
 			err = dbDeleteSiacoinOutput(tx, diff.ID)
 		}

--- a/node/api/hostdb_test.go
+++ b/node/api/hostdb_test.go
@@ -271,7 +271,7 @@ func assembleHostPort(key crypto.CipherKey, hostHostname string, testdir string)
 
 	// Create the siamux
 	siaMuxDir := filepath.Join(testdir, modules.SiaMuxDir)
-	mux, err := modules.NewSiaMux(siaMuxDir, testdir, "localhost:0", "localhost:0")
+	mux, _, err := modules.NewSiaMux(siaMuxDir, testdir, "localhost:0", "localhost:0")
 	if err != nil {
 		return nil, err
 	}

--- a/node/api/server_helpers_test.go
+++ b/node/api/server_helpers_test.go
@@ -171,7 +171,7 @@ func assembleServerTesterWithDeps(key crypto.CipherKey, testdir string, gDeps, c
 
 	// Create the siamux
 	siaMuxDir := filepath.Join(testdir, modules.SiaMuxDir)
-	mux, err := modules.NewSiaMux(siaMuxDir, testdir, "localhost:0", "localhost:0")
+	mux, _, err := modules.NewSiaMux(siaMuxDir, testdir, "localhost:0", "localhost:0")
 	if err != nil {
 		return nil, err
 	}
@@ -286,7 +286,7 @@ func assembleAuthenticatedServerTester(requiredPassword string, key crypto.Ciphe
 
 	// Create the siamux.
 	siaMuxDir := filepath.Join(testdir, modules.SiaMuxDir)
-	mux, err := modules.NewSiaMux(siaMuxDir, testdir, "localhost:0", "localhost:0")
+	mux, _, err := modules.NewSiaMux(siaMuxDir, testdir, "localhost:0", "localhost:0")
 	if err != nil {
 		return nil, err
 	}

--- a/profile/server.go
+++ b/profile/server.go
@@ -1,3 +1,4 @@
+//go:build profile
 // +build profile
 
 package profile

--- a/sync/threadgroup.go
+++ b/sync/threadgroup.go
@@ -18,10 +18,11 @@ var ErrStopped = errors.New("ThreadGroup already stopped")
 // It is safe to call Add(), Done(), and Stop() concurrently, however it is not
 // safe to nest calls to Add(). A simple example of a nested call to add would
 // be:
-//		tg.Add()
-//		tg.Add()
-//		tg.Done()
-//		tg.Done()
+//
+//	tg.Add()
+//	tg.Add()
+//	tg.Done()
+//	tg.Done()
 type ThreadGroup struct {
 	onStopFns    []func()
 	afterStopFns []func()

--- a/types/block.go
+++ b/types/block.go
@@ -55,7 +55,7 @@ type (
 // CalculateCoinbase calculates the coinbase for a given height. The coinbase
 // equation is:
 //
-//     coinbase := max(InitialCoinbase - height, MinimumCoinbase) * SiacoinPrecision
+//	coinbase := max(InitialCoinbase - height, MinimumCoinbase) * SiacoinPrecision
 func CalculateCoinbase(height BlockHeight) Currency {
 	base := InitialCoinbase - uint64(height)
 	if uint64(height) > InitialCoinbase || base < MinimumCoinbase {

--- a/types/target.go
+++ b/types/target.go
@@ -29,7 +29,8 @@ var (
 // AddDifficulties returns the resulting target with the difficulty of 'x' and
 // 'y' are added together. Note that the difficulty is the inverse of the
 // target. The sum is defined by:
-//		sum(x, y) = 1/(1/x + 1/y)
+//
+//	sum(x, y) = 1/(1/x + 1/y)
 func (x Target) AddDifficulties(y Target) (t Target) {
 	sumDifficulty := new(big.Rat).Add(x.Inverse(), y.Inverse())
 	return RatToTarget(new(big.Rat).Inv(sumDifficulty))
@@ -37,9 +38,10 @@ func (x Target) AddDifficulties(y Target) (t Target) {
 
 // Cmp compares the difficulties of two targets. Note that the difficulty is
 // the inverse of the target. The results are as follows:
-//		-1 if x <  y
-//		 0 if x == y
-//		+1 if x >  y
+//
+//	-1 if x <  y
+//	 0 if x == y
+//	+1 if x >  y
 func (x Target) Cmp(y Target) int {
 	return x.Int().Cmp(y.Int())
 }
@@ -110,7 +112,8 @@ func RatToTarget(r *big.Rat) (t Target) {
 // SubtractDifficulties returns the resulting target with the difficulty of 'x'
 // is subtracted from the target with difficulty 'y'. Note that the difficulty
 // is the inverse of the target. The difference is defined by:
-//		sum(x, y) = 1/(1/x - 1/y)
+//
+//	sum(x, y) = 1/(1/x - 1/y)
 func (x Target) SubtractDifficulties(y Target) (t Target) {
 	sumDifficulty := new(big.Rat).Sub(x.Inverse(), y.Inverse())
 	return RatToTarget(new(big.Rat).Inv(sumDifficulty))

--- a/types/transaction_helpers.go
+++ b/types/transaction_helpers.go
@@ -36,23 +36,23 @@ type TransactionGraphEdge struct {
 //
 // Resulting Graph:
 //
-//    o
-//   / \
-//  o   o
-//   \ /
-//    o
-//   /|\
-//   \| \
-//    o  o
-//    |
-//    o
+//	  o
+//	 / \
+//	o   o
+//	 \ /
+//	  o
+//	 /|\
+//	 \| \
+//	  o  o
+//	  |
+//	  o
 //
 // This graph will result in 4 transactions:
 //
-//    t1: [0->1],[0->2]
-//    t2: [1->3],[2->3]
-//    t3: [3->4],[3->4],[3->5]
-//    t4: [4->6]
+//	t1: [0->1],[0->2]
+//	t2: [1->3],[2->3]
+//	t3: [3->4],[3->4],[3->5]
+//	t4: [4->6]
 //
 // NOTE: the edges must be specified so that the inputs and outputs of the
 // resulting transaction add up correctly.


### PR DESCRIPTION
This PR makes sure the log file of the siamux is closed as part of the `node.Close` call.

Renterd's integration tests fail on windows because deleting the log after the test fails due to the log not being closed.

NOTE: I verified that this change fixes the test by `go get`'ing this PR's latest commit.