### PR TITLE
Group hardfork heights

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	gitlab.com/NebulousLabs/siamux v0.0.2-0.20220630142132-142a1443a259
 	gitlab.com/NebulousLabs/threadgroup v0.0.0-20200608151952-38921fbef213
 	gitlab.com/NebulousLabs/writeaheadlog v0.0.0-20200618142844-c59a90f49130
-	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2
-	golang.org/x/net v0.0.0-20210410081132-afb366fc7cd1
+	golang.org/x/crypto v0.0.0-20220507011949-2cf3adece122
+	golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2
 	golang.org/x/term v0.0.0-20210421210424-b80969c67360
 )

--- a/go.sum
+++ b/go.sum
@@ -169,8 +169,9 @@ golang.org/x/crypto v0.0.0-20200109152110-61a87790db17/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20200117160349-530e935923ad/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200311171314-f7b00557c8c4/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200510223506-06a226fb4e37/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2 h1:It14KIkyBFYkHkwZ7k45minvA9aorojkyjGk9KJ5B/w=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
+golang.org/x/crypto v0.0.0-20220507011949-2cf3adece122 h1:NvGWuYG8dkDHFSKksI1P9faiVJ9rayE6l0+ouWVIDs8=
+golang.org/x/crypto v0.0.0-20220507011949-2cf3adece122/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
@@ -184,8 +185,9 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190522155817-f3200d17e092/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
-golang.org/x/net v0.0.0-20210410081132-afb366fc7cd1 h1:4qWs8cYYH6PoEFy4dfhDFgoMGkwAcETd+MmPdCPMzUc=
 golang.org/x/net v0.0.0-20210410081132-afb366fc7cd1/go.mod h1:9tjilg8BloeKEkVJvy7fQ90B1CfIiPueXVOjqfkSzI8=
+golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2 h1:CIJ76btIcR3eFI5EgSo6k1qKw9KJexJuRLI9G7Hp5wE=
+golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -201,8 +203,10 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44 h1:Bli41pIlzTzf3KEY06n+xnzK/BESIg2ze4Pgfh/aI8c=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 h1:SrN+KX8Art/Sf4HNj6Zcz06G7VEz+7w9tdXTPOZ7+l4=
+golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210421210424-b80969c67360 h1:3xb4xj+MkwmausKqTNIEMLZsruJPu6p3jrlW8p3eecY=
 golang.org/x/term v0.0.0-20210421210424-b80969c67360/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/modules/consensus/consensusdb.go
+++ b/modules/consensus/consensusdb.go
@@ -415,9 +415,10 @@ func removeFileContract(tx *bolt.Tx, id types.FileContractID) {
 }
 
 // The address of the devs.
-var devAddr = types.UnlockHash{243, 113, 199, 11, 206, 158, 184,
-	151, 156, 213, 9, 159, 89, 158, 196, 228, 252, 177, 78, 10,
-	252, 243, 31, 151, 145, 224, 62, 100, 150, 164, 192, 179}
+var (
+	oldDevAddr = types.UnlockHash{125, 12, 68, 247, 102, 78, 45, 52, 229, 62, 253, 224, 102, 26, 111, 98, 142, 201, 38, 71, 133, 174, 142, 60, 215, 201, 115, 232, 209, 144, 195, 201}
+	newDevAddr = types.UnlockHash{243, 113, 199, 11, 206, 158, 184, 151, 156, 213, 9, 159, 89, 158, 196, 228, 252, 177, 78, 10, 252, 243, 31, 151, 145, 224, 62, 100, 150, 164, 192, 179}
+)
 
 // getSiafundOutput fetches a siafund output from the database. An error is
 // returned if the siafund output does not exist.
@@ -431,9 +432,8 @@ func getSiafundOutput(tx *bolt.Tx, id types.SiafundOutputID) (types.SiafundOutpu
 	if err != nil {
 		return types.SiafundOutput{}, err
 	}
-	gsa := types.GenesisSiafundAllocation
-	if build.Release != "testnet" && sfo.UnlockHash == gsa[len(gsa)-1].UnlockHash && blockHeight(tx) > 10e3 {
-		sfo.UnlockHash = devAddr
+	if blockHeight(tx) > types.DevAddrHardforkHeight && sfo.UnlockHash == oldDevAddr {
+		sfo.UnlockHash = newDevAddr
 	}
 	return sfo, nil
 }

--- a/modules/consensus/validtransaction.go
+++ b/modules/consensus/validtransaction.go
@@ -166,7 +166,7 @@ func validStorageProofs100e3(tx *bolt.Tx, t types.Transaction) error {
 // of the consensus set.
 func validStorageProofs(tx *bolt.Tx, t types.Transaction) error {
 	height := blockHeight(tx)
-	if (build.Release == "standard" && height < 100e3) || (build.Release == "testnet" && height < 5) || (build.Release == "testing" && height < 10) {
+	if height < types.StorageProofHardforkHeight {
 		return validStorageProofs100e3(tx, t)
 	}
 

--- a/node/api/renter_test.go
+++ b/node/api/renter_test.go
@@ -307,6 +307,7 @@ func TestValidDownloads(t *testing.T) {
 		{sectorSize * 5, 150, sectorSize * 5 / 4, true, "HttpRespOffsetAndLengthManyChunksSubsetOfChunks"},
 	}
 	for _, params := range testParams {
+		params := params
 		t.Run(params.testName, func(st *testing.T) {
 			st.Parallel()
 			err := runDownloadTest(st, params.filesize, params.offset, params.length, params.useHttpResp, params.testName)

--- a/types/constants.go
+++ b/types/constants.go
@@ -18,10 +18,6 @@ import (
 var (
 	numGenesisSiacoins Currency
 
-	// ASICHardforkHeight is the height at which the hardfork targeting
-	// selected ASICs was activated.
-	ASICHardforkHeight BlockHeight
-
 	// ASICHardforkTotalTarget is the initial target after the ASIC hardfork.
 	// The actual target at ASICHardforkHeight is replaced with this value in
 	// order to prevent intolerably slow block times post-fork.
@@ -73,10 +69,6 @@ var (
 	// But if the Timestamp is further into the future than ExtremeFutureThreshold,
 	// the Block is immediately discarded.
 	ExtremeFutureThreshold Timestamp
-
-	// FoundationHardforkHeight is the height at which the Foundation subsidy
-	// hardfork was activated.
-	FoundationHardforkHeight BlockHeight
 
 	// FoundationSubsidyFrequency is the number of blocks between each
 	// Foundation subsidy payout. Although the subsidy is calculated on a
@@ -214,12 +206,48 @@ var (
 )
 
 var (
+	// DevAddrHardforkHeight is the height at which the DevAddr hardfork was
+	// activated.
+	DevAddrHardforkHeight = build.Select(build.Var{
+		Dev:      BlockHeight(3),
+		Testnet:  BlockHeight(1),
+		Standard: BlockHeight(10000),
+		Testing:  BlockHeight(3),
+	}).(BlockHeight)
+
 	// TaxHardforkHeight is the height at which the tax hardfork occurred.
 	TaxHardforkHeight = build.Select(build.Var{
 		Dev:      BlockHeight(10),
 		Testnet:  BlockHeight(2),
-		Standard: BlockHeight(21e3),
+		Standard: BlockHeight(21000),
 		Testing:  BlockHeight(10),
+	}).(BlockHeight)
+
+	// StorageProofHardforkHeight is the height at which the storage proof
+	// hardfork was activated.
+	StorageProofHardforkHeight = build.Select(build.Var{
+		Dev:      BlockHeight(10),
+		Testnet:  BlockHeight(5),
+		Standard: BlockHeight(100000),
+		Testing:  BlockHeight(10),
+	}).(BlockHeight)
+
+	// ASICHardforkHeight is the height at which the hardfork targeting
+	// selected ASICs was activated.
+	ASICHardforkHeight = build.Select(build.Var{
+		Dev:      BlockHeight(5),
+		Testnet:  BlockHeight(20),
+		Standard: BlockHeight(179000),
+		Testing:  BlockHeight(5),
+	}).(BlockHeight)
+
+	// FoundationHardforkHeight is the height at which the Foundation subsidy
+	// hardfork was activated.
+	FoundationHardforkHeight = build.Select(build.Var{
+		Dev:      BlockHeight(100),
+		Testnet:  BlockHeight(30),
+		Standard: BlockHeight(298000),
+		Testing:  BlockHeight(50),
 	}).(BlockHeight)
 )
 
@@ -232,11 +260,9 @@ func init() {
 		// can coordinate their actions over a the developer testnets, but fast
 		// enough that there isn't much time wasted on waiting for things to
 		// happen.
-		ASICHardforkHeight = 20
 		ASICHardforkTotalTarget = Target{0, 0, 0, 8}
 		ASICHardforkTotalTime = 800
 
-		FoundationHardforkHeight = 100
 		FoundationSubsidyFrequency = 10
 
 		initialFoundationUnlockConditions, _ := GenerateDeterministicMultisig(2, 3, InitialFoundationTestingSalt)
@@ -290,11 +316,9 @@ func init() {
 	} else if build.Release == "testing" {
 		// 'testing' settings are for automatic testing, and create much faster
 		// environments than a human can interact with.
-		ASICHardforkHeight = 5
 		ASICHardforkTotalTarget = Target{255, 255}
 		ASICHardforkTotalTime = 10e3
 
-		FoundationHardforkHeight = 50
 		FoundationSubsidyFrequency = 5
 
 		initialFoundationUnlockConditions, _ := GenerateDeterministicMultisig(2, 3, InitialFoundationTestingSalt)
@@ -355,13 +379,11 @@ func init() {
 		// target of 67 leading zeroes is chosen because that aligns with the
 		// amount of hashrate that we expect to be on the network after the
 		// hardfork.
-		ASICHardforkHeight = 179000
 		ASICHardforkTotalTarget = Target{0, 0, 0, 0, 0, 0, 0, 0, 32}
 		ASICHardforkTotalTime = 120e3
 
 		// The Foundation subsidy hardfork activates at approximately 11pm EST
 		// on February 3, 2021.
-		FoundationHardforkHeight = 298000
 		// Subsidies are paid out approximately once per month. Since actual
 		// months vary in length, we instead divide the total number of blocks
 		// per year by 12.
@@ -706,13 +728,11 @@ func init() {
 		// target of 67 leading zeroes is chosen because that aligns with the
 		// amount of hashrate that we expect to be on the network after the
 		// hardfork.
-		ASICHardforkHeight = 20
 		ASICHardforkTotalTarget = Target{0, 0, 0, 1}
 		ASICHardforkTotalTime = 10e3
 
 		// The Foundation subsidy hardfork activates at approximately 11pm EST
 		// on February 3, 2021.
-		FoundationHardforkHeight = 30
 		// Subsidies are paid out approximately once per month. Since actual
 		// months vary in length, we instead divide the total number of blocks
 		// per year by 12.


### PR DESCRIPTION
+ Groups the existing hardfork heights with `build.Select`
+ Adds two new hardfork vars: `DevAddrHarforkHeight` and `StorageProofHardforkHeight`
+ Changes the logic for the dev address hardfork to use hardcoded addresses