### PR TITLE
Put a cap on the expectedExchange within verifyClearingRevision

### DIFF
--- a/modules/host/negotiaterevisecontract.go
+++ b/modules/host/negotiaterevisecontract.go
@@ -401,6 +401,9 @@ func verifyClearingRevision(oldFCR, revision types.FileContractRevision, blockHe
 	}
 	fromRenter := oldFCR.ValidRenterPayout().Sub(revision.ValidRenterPayout())
 	// Verify that enough money was transferred.
+	if expectedExchange.Cmp(oldFCR.ValidRenterPayout()) > 0 {
+		expectedExchange = oldFCR.ValidRenterPayout()
+	}
 	if fromRenter.Cmp(expectedExchange) < 0 {
 		s := fmt.Sprintf("expected at least %v to be exchanged, but %v was exchanged: ", expectedExchange, fromRenter)
 		return extendErr(s, ErrHighRenterValidOutput)


### PR DESCRIPTION
To avoid contracts failing to renew when they are completely drained, I put a cap on the `expectedExchange` in `verifyClearingRevision`.

rhpv3 doesn't suffer from that issue since we always pass 0 but in rhpv2 we might fail to renew drained contracts which is not something that either renter nor host would want on a well-used contract.